### PR TITLE
feat(worker-proxy): improve HTTP forwarding telemetry

### DIFF
--- a/src/Functions.WorkerProxy/Http/WorkerEndpointReadinessProbe.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerEndpointReadinessProbe.cs
@@ -47,14 +47,16 @@ internal sealed partial class WorkerEndpointReadinessProbe(
     /// </summary>
     /// <param name="destination">The destination to probe.</param>
     /// <param name="cancellationToken">The caller cancellation token.</param>
-    /// <returns><see langword="true"/> when ready; otherwise, <see langword="false"/>.</returns>
-    public async ValueTask<bool> WaitForReadyAsync(Uri destination, CancellationToken cancellationToken)
+    /// <returns>The bounded readiness result.</returns>
+    public async ValueTask<WorkerEndpointReadinessResult> WaitForReadyAsync(
+        Uri destination,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(destination);
 
         if (_readyDestinations.ContainsKey(destination))
         {
-            return true;
+            return WorkerEndpointReadinessResult.Ready;
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -79,7 +81,7 @@ internal sealed partial class WorkerEndpointReadinessProbe(
             catch (SocketException exception)
             {
                 Log.DestinationResolutionFailed(_logger, exception, destination);
-                return false;
+                return WorkerEndpointReadinessResult.NameResolutionFailed;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -88,14 +90,14 @@ internal sealed partial class WorkerEndpointReadinessProbe(
             catch (OperationCanceledException)
             {
                 Log.DestinationNotReady(_logger, lastError, destination, stopwatch.Elapsed, attempts);
-                return false;
+                return GetFailureResult(lastError);
             }
         }
 
         if (addresses.Length == 0)
         {
             Log.DestinationResolutionFailed(_logger, exception: null, destination);
-            return false;
+            return WorkerEndpointReadinessResult.NameResolutionFailed;
         }
 
         while (!deadline.IsCancellationRequested)
@@ -113,7 +115,7 @@ internal sealed partial class WorkerEndpointReadinessProbe(
                         Log.DestinationReady(_logger, destination, stopwatch.Elapsed.TotalMilliseconds, attempts);
                     }
 
-                    return true;
+                    return WorkerEndpointReadinessResult.Ready;
                 }
                 catch (SocketException exception)
                 {
@@ -126,7 +128,7 @@ internal sealed partial class WorkerEndpointReadinessProbe(
                 catch (OperationCanceledException)
                 {
                     Log.DestinationNotReady(_logger, lastError, destination, stopwatch.Elapsed, attempts);
-                    return false;
+                    return GetFailureResult(lastError);
                 }
             }
 
@@ -141,14 +143,27 @@ internal sealed partial class WorkerEndpointReadinessProbe(
             catch (OperationCanceledException)
             {
                 Log.DestinationNotReady(_logger, lastError, destination, stopwatch.Elapsed, attempts);
-                return false;
+                return GetFailureResult(lastError);
             }
         }
 
         cancellationToken.ThrowIfCancellationRequested();
         Log.DestinationNotReady(_logger, lastError, destination, stopwatch.Elapsed, attempts);
 
-        return false;
+        return GetFailureResult(lastError);
+    }
+
+    private static WorkerEndpointReadinessResult GetFailureResult(Exception? lastError)
+    {
+        return lastError switch
+        {
+            SocketException { SocketErrorCode: SocketError.ConnectionRefused } =>
+                WorkerEndpointReadinessResult.ConnectionRefused,
+            SocketException { SocketErrorCode: SocketError.TimedOut } =>
+                WorkerEndpointReadinessResult.Timeout,
+            SocketException => WorkerEndpointReadinessResult.ConnectionFailed,
+            _ => WorkerEndpointReadinessResult.Timeout
+        };
     }
 
     private static partial class Log

--- a/src/Functions.WorkerProxy/Http/WorkerEndpointReadinessProbe.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerEndpointReadinessProbe.cs
@@ -49,8 +49,7 @@ internal sealed partial class WorkerEndpointReadinessProbe(
     /// <param name="cancellationToken">The caller cancellation token.</param>
     /// <returns>The bounded readiness result.</returns>
     public async ValueTask<WorkerEndpointReadinessResult> WaitForReadyAsync(
-        Uri destination,
-        CancellationToken cancellationToken)
+        Uri destination, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(destination);
 

--- a/src/Functions.WorkerProxy/Http/WorkerEndpointReadinessResult.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerEndpointReadinessResult.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Azure.Functions.WorkerProxy.Http;
+
+/// <summary>
+/// Describes the result of waiting for a worker HTTP destination.
+/// </summary>
+internal enum WorkerEndpointReadinessResult
+{
+    Ready,
+    NameResolutionFailed,
+    ConnectionRefused,
+    Timeout,
+    ConnectionFailed
+}

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwarder.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwarder.cs
@@ -13,8 +13,8 @@ namespace Azure.Functions.WorkerProxy.Http;
 /// Streams HTTP requests and responses between the runtime and worker.
 /// </summary>
 internal sealed class WorkerHttpForwarder(
-    IHttpForwarder httpForwarder,
-    IHttpMessageHandlerFactory httpMessageHandlerFactory) : IDisposable
+    IHttpForwarder httpForwarder, IHttpMessageHandlerFactory httpMessageHandlerFactory)
+    : IDisposable
 {
     private static readonly ForwarderRequestConfig RequestConfig = new()
     {

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
@@ -29,27 +29,26 @@ internal sealed class WorkerHttpForwardingMiddleware(
         if (destination is null)
         {
             context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-            WorkerHttpForwardingTelemetry.RecordDestinationNotConfigured(context);
+            WorkerHttpForwardingTelemetry.RecordDestinationNotConfigured();
             return;
         }
 
-        if (!readinessProbe.IsKnownReady(destination)
-            && !await readinessProbe.WaitForReadyAsync(destination, context.RequestAborted))
+        if (!readinessProbe.IsKnownReady(destination))
         {
-            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-            WorkerHttpForwardingTelemetry.RecordDestinationNotReady(context);
-            return;
+            WorkerEndpointReadinessResult readinessResult =
+                await readinessProbe.WaitForReadyAsync(destination, context.RequestAborted);
+
+            if (readinessResult is not WorkerEndpointReadinessResult.Ready)
+            {
+                context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                WorkerHttpForwardingTelemetry.RecordDestinationNotReady(readinessResult);
+                return;
+            }
         }
 
         ForwarderError error = await forwarder.ForwardAsync(context, destination);
-        if (error is ForwarderError.None)
+        if (error is ForwarderError.None || context.RequestAborted.IsCancellationRequested)
         {
-            return;
-        }
-
-        if (context.RequestAborted.IsCancellationRequested)
-        {
-            WorkerHttpForwardingTelemetry.RecordCanceled(context);
             return;
         }
 
@@ -58,6 +57,6 @@ internal sealed class WorkerHttpForwardingMiddleware(
             context.Response.StatusCode = StatusCodes.Status502BadGateway;
         }
 
-        WorkerHttpForwardingTelemetry.RecordForwarderError(context, error);
+        WorkerHttpForwardingTelemetry.RecordForwarderError(error);
     }
 }

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
@@ -28,16 +28,16 @@ internal sealed class WorkerHttpForwardingMiddleware(
 
         if (destination is null)
         {
-            WorkerHttpForwardingTelemetry.RecordDestinationNotConfigured(context);
             context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            WorkerHttpForwardingTelemetry.RecordDestinationNotConfigured(context);
             return;
         }
 
         if (!readinessProbe.IsKnownReady(destination)
             && !await readinessProbe.WaitForReadyAsync(destination, context.RequestAborted))
         {
-            WorkerHttpForwardingTelemetry.RecordDestinationNotReady(context);
             context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            WorkerHttpForwardingTelemetry.RecordDestinationNotReady(context);
             return;
         }
 
@@ -53,10 +53,11 @@ internal sealed class WorkerHttpForwardingMiddleware(
             return;
         }
 
-        WorkerHttpForwardingTelemetry.RecordForwarderError(context, error);
         if (!context.Response.HasStarted)
         {
             context.Response.StatusCode = StatusCodes.Status502BadGateway;
         }
+
+        WorkerHttpForwardingTelemetry.RecordForwarderError(context, error);
     }
 }

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
@@ -13,9 +13,7 @@ namespace Azure.Functions.WorkerProxy.Http;
 /// Resolves the worker endpoint, waits for readiness, and forwards eligible requests through YARP.
 /// </summary>
 internal sealed class WorkerHttpForwardingMiddleware(
-    IOptions<WorkerProxyOptions> options,
-    WorkerEndpointReadinessProbe readinessProbe,
-    WorkerHttpForwarder forwarder)
+    IOptions<WorkerProxyOptions> options, WorkerEndpointReadinessProbe readinessProbe, WorkerHttpForwarder forwarder)
 {
     /// <summary>
     /// Forwards a request to the configured worker HTTP endpoint.

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
@@ -44,7 +44,6 @@ internal sealed class WorkerHttpForwardingMiddleware(
         ForwarderError error = await forwarder.ForwardAsync(context, destination);
         if (error is ForwarderError.None)
         {
-            WorkerHttpForwardingTelemetry.RecordSuccess(context);
             return;
         }
 

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingMiddleware.cs
@@ -26,16 +26,36 @@ internal sealed class WorkerHttpForwardingMiddleware(
         Uri? destination = WorkerHttpDestinationResolver.Resolve(
             options.Value.WorkerHttpEndpoint, advertisedEndpoint: null);
 
-        if (destination is null || (!readinessProbe.IsKnownReady(destination)
-            && !await readinessProbe.WaitForReadyAsync(destination, context.RequestAborted)))
+        if (destination is null)
         {
+            WorkerHttpForwardingTelemetry.RecordDestinationNotConfigured(context);
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return;
+        }
+
+        if (!readinessProbe.IsKnownReady(destination)
+            && !await readinessProbe.WaitForReadyAsync(destination, context.RequestAborted))
+        {
+            WorkerHttpForwardingTelemetry.RecordDestinationNotReady(context);
             context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             return;
         }
 
         ForwarderError error = await forwarder.ForwardAsync(context, destination);
-        if (error is not ForwarderError.None && !context.RequestAborted.IsCancellationRequested
-            && !context.Response.HasStarted)
+        if (error is ForwarderError.None)
+        {
+            WorkerHttpForwardingTelemetry.RecordSuccess(context);
+            return;
+        }
+
+        if (context.RequestAborted.IsCancellationRequested)
+        {
+            WorkerHttpForwardingTelemetry.RecordCanceled(context);
+            return;
+        }
+
+        WorkerHttpForwardingTelemetry.RecordForwarderError(context, error);
+        if (!context.Response.HasStarted)
         {
             context.Response.StatusCode = StatusCodes.Status502BadGateway;
         }

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
 using Yarp.ReverseProxy.Forwarder;
 
@@ -15,14 +14,9 @@ internal static class WorkerHttpForwardingTelemetry
     internal const string ForwardingResultAttribute = "azure.functions.worker_proxy.http.forwarding.result";
     internal const string ForwarderErrorAttribute = "azure.functions.worker_proxy.http.forwarding.error";
 
-    internal const string DestinationNotConfiguredResult = "destination_not_configured";
-    internal const string DestinationNotReadyResult = "destination_not_ready";
-    internal const string ForwarderErrorResult = "forwarder_error";
-
-    internal const string NameResolutionFailedError = "name_resolution_failed";
-    internal const string ConnectionRefusedError = "connection_refused";
-    internal const string TimeoutError = "timeout";
-    internal const string ConnectionFailedError = "connection_failed";
+    internal const string DestinationNotConfiguredResult = "DestinationNotConfigured";
+    internal const string DestinationNotReadyResult = "DestinationNotReady";
+    internal const string ForwarderErrorResult = "ForwarderError";
 
     /// <summary>
     /// Records that no worker HTTP destination was configured or advertised.
@@ -37,16 +31,7 @@ internal static class WorkerHttpForwardingTelemetry
     /// </summary>
     public static void RecordDestinationNotReady(WorkerEndpointReadinessResult readinessResult)
     {
-        string error = readinessResult switch
-        {
-            WorkerEndpointReadinessResult.NameResolutionFailed => NameResolutionFailedError,
-            WorkerEndpointReadinessResult.ConnectionRefused => ConnectionRefusedError,
-            WorkerEndpointReadinessResult.Timeout => TimeoutError,
-            WorkerEndpointReadinessResult.ConnectionFailed => ConnectionFailedError,
-            _ => throw new ArgumentOutOfRangeException(nameof(readinessResult))
-        };
-
-        RecordFailure(DestinationNotReadyResult, error);
+        RecordFailure(DestinationNotReadyResult, readinessResult.ToString());
     }
 
     /// <summary>

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
@@ -16,7 +16,6 @@ internal static class WorkerHttpForwardingTelemetry
     internal const string ForwardingResultAttribute = "azure.functions.worker_proxy.http.forwarding.result";
     internal const string ErrorTypeAttribute = "error.type";
 
-    internal const string SuccessResult = "success";
     internal const string CanceledResult = "canceled";
     internal const string DestinationNotConfiguredResult = "destination_not_configured";
     internal const string DestinationNotReadyResult = "destination_not_ready";
@@ -25,14 +24,6 @@ internal static class WorkerHttpForwardingTelemetry
     internal const string DestinationNotConfiguredErrorType = "worker_http_destination_not_configured";
     internal const string DestinationNotReadyErrorType = "worker_http_destination_not_ready";
     internal const string ForwarderErrorTypePrefix = "Yarp.ReverseProxy.Forwarder.ForwarderError.";
-
-    /// <summary>
-    /// Records a successful forwarding operation.
-    /// </summary>
-    public static void RecordSuccess(HttpContext context)
-    {
-        SetResult(context, SuccessResult);
-    }
 
     /// <summary>
     /// Records that forwarding was canceled by the caller.

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
@@ -1,10 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
-using System.Globalization;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Yarp.ReverseProxy.Forwarder;
 
 namespace Azure.Functions.WorkerProxy.Http;
@@ -16,75 +14,59 @@ internal static class WorkerHttpForwardingTelemetry
 {
     internal const string ForwardingResultAttribute = "azure.functions.worker_proxy.http.forwarding.result";
     internal const string ForwarderErrorAttribute = "azure.functions.worker_proxy.http.forwarding.error";
-    internal const string ErrorTypeAttribute = "error.type";
 
-    internal const string CanceledResult = "canceled";
     internal const string DestinationNotConfiguredResult = "destination_not_configured";
     internal const string DestinationNotReadyResult = "destination_not_ready";
     internal const string ForwarderErrorResult = "forwarder_error";
 
-    internal const string ForwarderErrorTypePrefix = "Yarp.ReverseProxy.Forwarder.ForwarderError.";
-
-    /// <summary>
-    /// Records that forwarding was canceled by the caller.
-    /// </summary>
-    public static void RecordCanceled(HttpContext context)
-    {
-        SetResult(context, CanceledResult);
-    }
+    internal const string NameResolutionFailedError = "name_resolution_failed";
+    internal const string ConnectionRefusedError = "connection_refused";
+    internal const string TimeoutError = "timeout";
+    internal const string ConnectionFailedError = "connection_failed";
 
     /// <summary>
     /// Records that no worker HTTP destination was configured or advertised.
     /// </summary>
-    public static void RecordDestinationNotConfigured(HttpContext context)
+    public static void RecordDestinationNotConfigured()
     {
-        SetError(context, DestinationNotConfiguredResult);
+        RecordFailure(DestinationNotConfiguredResult);
     }
 
     /// <summary>
     /// Records that the worker HTTP destination did not become ready.
     /// </summary>
-    public static void RecordDestinationNotReady(HttpContext context)
+    public static void RecordDestinationNotReady(WorkerEndpointReadinessResult readinessResult)
     {
-        SetError(context, DestinationNotReadyResult);
+        string error = readinessResult switch
+        {
+            WorkerEndpointReadinessResult.NameResolutionFailed => NameResolutionFailedError,
+            WorkerEndpointReadinessResult.ConnectionRefused => ConnectionRefusedError,
+            WorkerEndpointReadinessResult.Timeout => TimeoutError,
+            WorkerEndpointReadinessResult.ConnectionFailed => ConnectionFailedError,
+            _ => throw new ArgumentOutOfRangeException(nameof(readinessResult))
+        };
+
+        RecordFailure(DestinationNotReadyResult, error);
     }
 
     /// <summary>
     /// Records an error returned by the YARP HTTP forwarder.
     /// </summary>
-    public static void RecordForwarderError(HttpContext context, ForwarderError error)
+    public static void RecordForwarderError(ForwarderError error)
     {
-        SetError(context, ForwarderErrorResult, error);
+        RecordFailure(ForwarderErrorResult, error.ToString());
     }
 
-    private static void SetResult(HttpContext context, string result)
+    private static void RecordFailure(string result, string? error = null)
     {
-        GetRequestActivity(context)?.SetTag(ForwardingResultAttribute, result);
-    }
-
-    private static void SetError(HttpContext context, string result, ForwarderError? forwarderError = null)
-    {
-        Activity? activity = GetRequestActivity(context);
+        Activity? activity = Activity.Current;
         activity?.SetTag(ForwardingResultAttribute, result);
 
-        if (forwarderError is not null)
+        if (error is not null)
         {
-            activity?.SetTag(ForwarderErrorAttribute, forwarderError.Value.ToString());
-        }
-
-        if (activity?.GetTagItem(ErrorTypeAttribute) is null)
-        {
-            string errorType = context.Response.StatusCode >= StatusCodes.Status500InternalServerError
-                ? context.Response.StatusCode.ToString(CultureInfo.InvariantCulture)
-                : $"{ForwarderErrorTypePrefix}{forwarderError}";
-            activity?.SetTag(ErrorTypeAttribute, errorType);
+            activity?.SetTag(ForwarderErrorAttribute, error);
         }
 
         activity?.SetStatus(ActivityStatusCode.Error);
-    }
-
-    private static Activity? GetRequestActivity(HttpContext context)
-    {
-        return context.Features.Get<IHttpActivityFeature>()?.Activity;
     }
 }

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Yarp.ReverseProxy.Forwarder;
+
+namespace Azure.Functions.WorkerProxy.Http;
+
+/// <summary>
+/// Enriches the inbound HTTP request activity with worker forwarding outcomes.
+/// </summary>
+internal static class WorkerHttpForwardingTelemetry
+{
+    internal const string ForwardingResultAttribute = "azure.functions.worker_proxy.http.forwarding.result";
+    internal const string ErrorTypeAttribute = "error.type";
+
+    internal const string SuccessResult = "success";
+    internal const string CanceledResult = "canceled";
+    internal const string DestinationNotConfiguredResult = "destination_not_configured";
+    internal const string DestinationNotReadyResult = "destination_not_ready";
+    internal const string ForwarderErrorResult = "forwarder_error";
+
+    internal const string DestinationNotConfiguredErrorType = "worker_http_destination_not_configured";
+    internal const string DestinationNotReadyErrorType = "worker_http_destination_not_ready";
+    internal const string ForwarderErrorTypePrefix = "Yarp.ReverseProxy.Forwarder.ForwarderError.";
+
+    /// <summary>
+    /// Records a successful forwarding operation.
+    /// </summary>
+    public static void RecordSuccess(HttpContext context)
+    {
+        SetResult(context, SuccessResult);
+    }
+
+    /// <summary>
+    /// Records that forwarding was canceled by the caller.
+    /// </summary>
+    public static void RecordCanceled(HttpContext context)
+    {
+        SetResult(context, CanceledResult);
+    }
+
+    /// <summary>
+    /// Records that no worker HTTP destination was configured or advertised.
+    /// </summary>
+    public static void RecordDestinationNotConfigured(HttpContext context)
+    {
+        SetError(context, DestinationNotConfiguredResult, DestinationNotConfiguredErrorType);
+    }
+
+    /// <summary>
+    /// Records that the worker HTTP destination did not become ready.
+    /// </summary>
+    public static void RecordDestinationNotReady(HttpContext context)
+    {
+        SetError(context, DestinationNotReadyResult, DestinationNotReadyErrorType);
+    }
+
+    /// <summary>
+    /// Records an error returned by the YARP HTTP forwarder.
+    /// </summary>
+    public static void RecordForwarderError(HttpContext context, ForwarderError error)
+    {
+        SetError(context, ForwarderErrorResult, $"{ForwarderErrorTypePrefix}{error}");
+    }
+
+    private static void SetResult(HttpContext context, string result)
+    {
+        GetRequestActivity(context)?.SetTag(ForwardingResultAttribute, result);
+    }
+
+    private static void SetError(HttpContext context, string result, string errorType)
+    {
+        Activity? activity = GetRequestActivity(context);
+        activity?.SetTag(ForwardingResultAttribute, result);
+
+        if (activity?.GetTagItem(ErrorTypeAttribute) is null)
+        {
+            activity?.SetTag(ErrorTypeAttribute, errorType);
+        }
+
+        activity?.SetStatus(ActivityStatusCode.Error);
+    }
+
+    private static Activity? GetRequestActivity(HttpContext context)
+    {
+        return context.Features.Get<IHttpActivityFeature>()?.Activity;
+    }
+}

--- a/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
+++ b/src/Functions.WorkerProxy/Http/WorkerHttpForwardingTelemetry.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Yarp.ReverseProxy.Forwarder;
@@ -14,6 +15,7 @@ namespace Azure.Functions.WorkerProxy.Http;
 internal static class WorkerHttpForwardingTelemetry
 {
     internal const string ForwardingResultAttribute = "azure.functions.worker_proxy.http.forwarding.result";
+    internal const string ForwarderErrorAttribute = "azure.functions.worker_proxy.http.forwarding.error";
     internal const string ErrorTypeAttribute = "error.type";
 
     internal const string CanceledResult = "canceled";
@@ -21,8 +23,6 @@ internal static class WorkerHttpForwardingTelemetry
     internal const string DestinationNotReadyResult = "destination_not_ready";
     internal const string ForwarderErrorResult = "forwarder_error";
 
-    internal const string DestinationNotConfiguredErrorType = "worker_http_destination_not_configured";
-    internal const string DestinationNotReadyErrorType = "worker_http_destination_not_ready";
     internal const string ForwarderErrorTypePrefix = "Yarp.ReverseProxy.Forwarder.ForwarderError.";
 
     /// <summary>
@@ -38,7 +38,7 @@ internal static class WorkerHttpForwardingTelemetry
     /// </summary>
     public static void RecordDestinationNotConfigured(HttpContext context)
     {
-        SetError(context, DestinationNotConfiguredResult, DestinationNotConfiguredErrorType);
+        SetError(context, DestinationNotConfiguredResult);
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ internal static class WorkerHttpForwardingTelemetry
     /// </summary>
     public static void RecordDestinationNotReady(HttpContext context)
     {
-        SetError(context, DestinationNotReadyResult, DestinationNotReadyErrorType);
+        SetError(context, DestinationNotReadyResult);
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ internal static class WorkerHttpForwardingTelemetry
     /// </summary>
     public static void RecordForwarderError(HttpContext context, ForwarderError error)
     {
-        SetError(context, ForwarderErrorResult, $"{ForwarderErrorTypePrefix}{error}");
+        SetError(context, ForwarderErrorResult, error);
     }
 
     private static void SetResult(HttpContext context, string result)
@@ -62,13 +62,21 @@ internal static class WorkerHttpForwardingTelemetry
         GetRequestActivity(context)?.SetTag(ForwardingResultAttribute, result);
     }
 
-    private static void SetError(HttpContext context, string result, string errorType)
+    private static void SetError(HttpContext context, string result, ForwarderError? forwarderError = null)
     {
         Activity? activity = GetRequestActivity(context);
         activity?.SetTag(ForwardingResultAttribute, result);
 
+        if (forwarderError is not null)
+        {
+            activity?.SetTag(ForwarderErrorAttribute, forwarderError.Value.ToString());
+        }
+
         if (activity?.GetTagItem(ErrorTypeAttribute) is null)
         {
+            string errorType = context.Response.StatusCode >= StatusCodes.Status500InternalServerError
+                ? context.Response.StatusCode.ToString(CultureInfo.InvariantCulture)
+                : $"{ForwarderErrorTypePrefix}{forwarderError}";
             activity?.SetTag(ErrorTypeAttribute, errorType);
         }
 

--- a/src/Functions.WorkerProxy/WorkerProxyApplication.cs
+++ b/src/Functions.WorkerProxy/WorkerProxyApplication.cs
@@ -107,6 +107,7 @@ internal static class WorkerProxyApplication
         builder.Services.AddHttpClient(nameof(WorkerHttpForwarder))
             .ConfigurePrimaryHttpMessageHandler(static () => new SocketsHttpHandler
             {
+                ActivityHeadersPropagator = null,
                 AllowAutoRedirect = false,
                 AutomaticDecompression = DecompressionMethods.None,
                 UseCookies = false,

--- a/test/Functions.WorkerProxy.Tests/Functions.WorkerProxy.Tests.csproj
+++ b/test/Functions.WorkerProxy.Tests/Functions.WorkerProxy.Tests.csproj
@@ -13,6 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption
+      Include="Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData"
+      Value="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Google.Protobuf" VersionOverride="3.35.1" />
     <PackageReference Include="Grpc.AspNetCore" VersionOverride="2.76.0" />
     <PackageReference Include="Grpc.Core.Api" VersionOverride="2.76.0" />

--- a/test/Functions.WorkerProxy.Tests/WorkerEndpointReadinessProbeTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerEndpointReadinessProbeTests.cs
@@ -86,16 +86,19 @@ public class WorkerEndpointReadinessProbeTests
     }
 
     [Fact]
-    public async Task WaitForReadyAsync_DestinationNeverBinds_ReturnsTimeout()
+    public async Task WaitForReadyAsync_DestinationNeverBinds_ReturnsBoundedFailure()
     {
         int port = GetUnusedPort();
         WorkerEndpointReadinessProbe probe = CreateProbe(
             TimeSpan.FromMilliseconds(10),
             TimeSpan.FromMilliseconds(100));
 
-        Assert.Equal(
-            WorkerEndpointReadinessResult.Timeout,
-            await probe.WaitForReadyAsync(new Uri($"http://localhost:{port}"), CancellationToken.None));
+        Assert.Contains(
+            await probe.WaitForReadyAsync(new Uri($"http://localhost:{port}"), CancellationToken.None),
+            [
+                WorkerEndpointReadinessResult.ConnectionRefused,
+                WorkerEndpointReadinessResult.Timeout
+            ]);
     }
 
     private static int GetUnusedPort()

--- a/test/Functions.WorkerProxy.Tests/WorkerEndpointReadinessProbeTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerEndpointReadinessProbeTests.cs
@@ -16,21 +16,25 @@ namespace Azure.Functions.WorkerProxy.Tests;
 public class WorkerEndpointReadinessProbeTests
 {
     [Fact]
-    public async Task WaitForReadyAsync_ListeningDestination_CachesSuccess()
+    public async Task WaitForReadyAsync_ListeningDestination_ReturnsReadyAndCachesSuccess()
     {
         using TcpListener listener = new(IPAddress.Loopback, 0);
         listener.Start();
         Uri destination = new($"http://localhost:{((IPEndPoint)listener.LocalEndpoint).Port}");
         WorkerEndpointReadinessProbe probe = CreateProbe();
 
-        Assert.True(await probe.WaitForReadyAsync(destination, CancellationToken.None));
+        Assert.Equal(
+            WorkerEndpointReadinessResult.Ready,
+            await probe.WaitForReadyAsync(destination, CancellationToken.None));
         listener.Stop();
         Assert.True(probe.IsKnownReady(destination));
-        Assert.True(await probe.WaitForReadyAsync(destination, CancellationToken.None));
+        Assert.Equal(
+            WorkerEndpointReadinessResult.Ready,
+            await probe.WaitForReadyAsync(destination, CancellationToken.None));
     }
 
     [Fact]
-    public async Task WaitForReadyAsync_LocalhostBoundToIpv6_ReturnsTrue()
+    public async Task WaitForReadyAsync_LocalhostBoundToIpv6_ReturnsReady()
     {
         using TcpListener listener = new(IPAddress.IPv6Loopback, 0);
         listener.Server.DualMode = false;
@@ -38,7 +42,9 @@ public class WorkerEndpointReadinessProbeTests
         Uri destination = new($"http://localhost:{((IPEndPoint)listener.LocalEndpoint).Port}");
         WorkerEndpointReadinessProbe probe = CreateProbe();
 
-        Assert.True(await probe.WaitForReadyAsync(destination, CancellationToken.None));
+        Assert.Equal(
+            WorkerEndpointReadinessResult.Ready,
+            await probe.WaitForReadyAsync(destination, CancellationToken.None));
     }
 
     [Fact]
@@ -53,43 +59,43 @@ public class WorkerEndpointReadinessProbeTests
     }
 
     [Fact]
-    public async Task WaitForReadyAsync_UnresolvableDestination_ReturnsFalse()
+    public async Task WaitForReadyAsync_UnresolvableDestination_ReturnsNameResolutionFailed()
     {
         WorkerEndpointReadinessProbe probe = CreateProbe();
 
-        Assert.False(await probe.WaitForReadyAsync(
-            new Uri("http://host.invalid"),
-            CancellationToken.None));
+        Assert.Equal(
+            WorkerEndpointReadinessResult.NameResolutionFailed,
+            await probe.WaitForReadyAsync(new Uri("http://host.invalid"), CancellationToken.None));
     }
 
     [Fact]
-    public async Task WaitForReadyAsync_DestinationBindsDuringBudget_ReturnsTrue()
+    public async Task WaitForReadyAsync_DestinationBindsDuringBudget_ReturnsReady()
     {
         int port = GetUnusedPort();
         WorkerEndpointReadinessProbe probe = CreateProbe(
             TimeSpan.FromMilliseconds(10),
             TimeSpan.FromSeconds(2));
         using TcpListener listener = new(IPAddress.Loopback, port);
-        ValueTask<bool> ready = probe.WaitForReadyAsync(
+        ValueTask<WorkerEndpointReadinessResult> ready = probe.WaitForReadyAsync(
             new Uri($"http://localhost:{port}"),
             CancellationToken.None);
         await Task.Delay(100);
         listener.Start();
 
-        Assert.True(await ready);
+        Assert.Equal(WorkerEndpointReadinessResult.Ready, await ready);
     }
 
     [Fact]
-    public async Task WaitForReadyAsync_DestinationNeverBinds_ReturnsFalse()
+    public async Task WaitForReadyAsync_DestinationNeverBinds_ReturnsTimeout()
     {
         int port = GetUnusedPort();
         WorkerEndpointReadinessProbe probe = CreateProbe(
             TimeSpan.FromMilliseconds(10),
             TimeSpan.FromMilliseconds(100));
 
-        Assert.False(await probe.WaitForReadyAsync(
-            new Uri($"http://localhost:{port}"),
-            CancellationToken.None));
+        Assert.Equal(
+            WorkerEndpointReadinessResult.Timeout,
+            await probe.WaitForReadyAsync(new Uri($"http://localhost:{port}"), CancellationToken.None));
     }
 
     private static int GetUnusedPort()

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -3,13 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Functions.WorkerProxy.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -22,6 +25,11 @@ namespace Azure.Functions.WorkerProxy.Tests;
 
 public class WorkerHttpForwardingTests
 {
+    static WorkerHttpForwardingTests()
+    {
+        AppContext.SetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", false);
+    }
+
     [Fact]
     public async Task HttpListener_ForwardsStatusHeadersBodyAndQuery()
     {
@@ -44,6 +52,7 @@ public class WorkerHttpForwardingTests
         };
         await using WorkerProxyWebApplicationFactory factory = new(configuration);
         using HttpClient client = factory.CreateHttpForwardingClient();
+        using RequestActivityRecorder activityRecorder = new();
         using HttpRequestMessage request = new(HttpMethod.Post, "/invoke?name=worker")
         {
             Content = new StringContent("payload", Encoding.UTF8, "text/plain")
@@ -55,6 +64,14 @@ public class WorkerHttpForwardingTests
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.Equal("worker-value", response.Headers.GetValues("x-worker-header").Single());
         Assert.Equal("received:payload", await response.Content.ReadAsStringAsync());
+
+        Activity activity = await activityRecorder.WaitForActivityAsync();
+        AssertRequestActivity(activity, "POST", "/invoke");
+        Assert.Equal(
+            WorkerHttpForwardingTelemetry.SuccessResult,
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
+        Assert.Null(activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
+        Assert.Equal(ActivityStatusCode.Unset, activity.Status);
     }
 
     [Fact]
@@ -85,10 +102,92 @@ public class WorkerHttpForwardingTests
     {
         await using WorkerProxyWebApplicationFactory factory = new();
         using HttpClient client = factory.CreateHttpForwardingClient();
+        using RequestActivityRecorder activityRecorder = new();
 
         using HttpResponseMessage response = await client.GetAsync("/");
 
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+
+        Activity activity = await activityRecorder.WaitForActivityAsync();
+        AssertRequestActivity(activity, "GET", "/");
+        Assert.Equal(
+            WorkerHttpForwardingTelemetry.DestinationNotConfiguredResult,
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
+        Assert.Equal(
+            WorkerHttpForwardingTelemetry.DestinationNotConfiguredErrorType,
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+    }
+
+    [Fact]
+    public async Task HttpListener_DestinationNotReady_ReturnsServiceUnavailable()
+    {
+        int port = GetUnusedPort();
+        Dictionary<string, string?> configuration = new()
+        {
+            [$"{WorkerProxyOptions.SectionName}:{nameof(WorkerProxyOptions.WorkerHttpEndpoint)}"] =
+                $"http://localhost:{port}",
+            [$"{WorkerEndpointReadinessProbeOptions.SectionName}:{nameof(WorkerEndpointReadinessProbeOptions.RetryDelay)}"] =
+                "00:00:00.010",
+            [$"{WorkerEndpointReadinessProbeOptions.SectionName}:{nameof(WorkerEndpointReadinessProbeOptions.TotalTimeout)}"] =
+                "00:00:00.100"
+        };
+        await using WorkerProxyWebApplicationFactory factory = new(configuration);
+        using HttpClient client = factory.CreateHttpForwardingClient();
+        using RequestActivityRecorder activityRecorder = new();
+
+        using HttpResponseMessage response = await client.GetAsync("/not-ready");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+
+        Activity activity = await activityRecorder.WaitForActivityAsync();
+        AssertRequestActivity(activity, "GET", "/not-ready");
+        Assert.Equal(
+            WorkerHttpForwardingTelemetry.DestinationNotReadyResult,
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
+        Assert.Equal(
+            WorkerHttpForwardingTelemetry.DestinationNotReadyErrorType,
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+    }
+
+    [Fact]
+    public async Task HttpListener_ForwarderError_ReturnsBadGateway()
+    {
+        await using WebApplication worker = await StartWorkerAsync(context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status204NoContent;
+            return Task.CompletedTask;
+        });
+        Dictionary<string, string?> configuration = new()
+        {
+            [$"{WorkerProxyOptions.SectionName}:{nameof(WorkerProxyOptions.WorkerHttpEndpoint)}"] =
+                GetAddress(worker).AbsoluteUri
+        };
+        await using WorkerProxyWebApplicationFactory factory = new(configuration);
+        using HttpClient client = factory.CreateHttpForwardingClient();
+
+        using (HttpResponseMessage response = await client.GetAsync("/warmup"))
+        {
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        }
+
+        await worker.StopAsync();
+        using RequestActivityRecorder activityRecorder = new();
+
+        using HttpResponseMessage failedResponse = await client.GetAsync("/forwarding-failure");
+
+        Assert.Equal(HttpStatusCode.BadGateway, failedResponse.StatusCode);
+
+        Activity activity = await activityRecorder.WaitForActivityAsync();
+        AssertRequestActivity(activity, "GET", "/forwarding-failure");
+        Assert.Equal(
+            WorkerHttpForwardingTelemetry.ForwarderErrorResult,
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
+        Assert.Equal(
+            $"{WorkerHttpForwardingTelemetry.ForwarderErrorTypePrefix}Request",
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
 
     [Fact]
@@ -150,5 +249,67 @@ public class WorkerHttpForwardingTests
         IServer server = app.Services.GetRequiredService<IServer>();
         string address = server.Features.Get<IServerAddressesFeature>()!.Addresses.Single();
         return new Uri(address);
+    }
+
+    private static int GetUnusedPort()
+    {
+        using TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    private static void AssertRequestActivity(Activity activity, string method, string path)
+    {
+        Assert.Equal("Microsoft.AspNetCore", activity.Source.Name);
+        Assert.Equal(ActivityKind.Server, activity.Kind);
+        Assert.Equal(method, activity.GetTagItem("http.request.method"));
+        Assert.Equal("http", activity.GetTagItem("url.scheme"));
+        Assert.Equal(path, activity.GetTagItem("url.path"));
+        Assert.Single(activity.TagObjects.Where(tag => string.Equals(
+            tag.Key, "http.request.method", StringComparison.Ordinal)));
+        Assert.Single(activity.TagObjects.Where(tag => string.Equals(
+            tag.Key, "url.scheme", StringComparison.Ordinal)));
+        Assert.Single(activity.TagObjects.Where(tag => string.Equals(
+            tag.Key, "url.path", StringComparison.Ordinal)));
+    }
+
+    private sealed class RequestActivityRecorder : IDisposable
+    {
+        private readonly TaskCompletionSource<Activity> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly ActivityListener _listener;
+
+        public RequestActivityRecorder()
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source => string.Equals(
+                    source.Name, "Microsoft.AspNetCore", StringComparison.Ordinal),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity =>
+                {
+                    if (activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute) is not null)
+                    {
+                        _completion.TrySetResult(activity);
+                    }
+                }
+            };
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public async Task<Activity> WaitForActivityAsync()
+        {
+            return await _completion.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
     }
 }

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -68,7 +68,6 @@ public class WorkerHttpForwardingTests
         Activity activity = await activityRecorder.WaitForActivityAsync();
         AssertRequestActivity(activity, "POST", "/invoke");
         Assert.Null(activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
-        Assert.Null(activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
     }
 
@@ -111,9 +110,6 @@ public class WorkerHttpForwardingTests
         Assert.Equal(
             WorkerHttpForwardingTelemetry.DestinationNotConfiguredResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
-        Assert.Equal(
-            StatusCodes.Status503ServiceUnavailable.ToString(),
-            activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
 
@@ -144,8 +140,8 @@ public class WorkerHttpForwardingTests
             WorkerHttpForwardingTelemetry.DestinationNotReadyResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
         Assert.Equal(
-            StatusCodes.Status503ServiceUnavailable.ToString(),
-            activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
+            WorkerHttpForwardingTelemetry.TimeoutError,
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwarderErrorAttribute));
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
 
@@ -182,9 +178,6 @@ public class WorkerHttpForwardingTests
         Assert.Equal(
             WorkerHttpForwardingTelemetry.ForwarderErrorResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
-        Assert.Equal(
-            StatusCodes.Status502BadGateway.ToString(),
-            activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
         Assert.Equal(
             Yarp.ReverseProxy.Forwarder.ForwarderError.Request.ToString(),
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwarderErrorAttribute));

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -309,14 +308,5 @@ public class WorkerHttpForwardingTests
         {
             _listener.Dispose();
         }
-    }
-}
-
-internal static class WorkerHttpForwardingTestsModuleInitializer
-{
-    [ModuleInitializer]
-    public static void Initialize()
-    {
-        AppContext.SetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", false);
     }
 }

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,11 +26,6 @@ namespace Azure.Functions.WorkerProxy.Tests;
 
 public class WorkerHttpForwardingTests
 {
-    static WorkerHttpForwardingTests()
-    {
-        AppContext.SetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", false);
-    }
-
     [Fact]
     public async Task HttpListener_ForwardsStatusHeadersBodyAndQuery()
     {
@@ -313,5 +309,14 @@ public class WorkerHttpForwardingTests
         {
             _listener.Dispose();
         }
+    }
+}
+
+internal static class WorkerHttpForwardingTestsModuleInitializer
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        AppContext.SetSwitch("Microsoft.AspNetCore.Hosting.SuppressActivityOpenTelemetryData", false);
     }
 }

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -52,7 +52,7 @@ public class WorkerHttpForwardingTests
         };
         await using WorkerProxyWebApplicationFactory factory = new(configuration);
         using HttpClient client = factory.CreateHttpForwardingClient();
-        using RequestActivityRecorder activityRecorder = new();
+        using RequestActivityRecorder activityRecorder = new("/invoke");
         using HttpRequestMessage request = new(HttpMethod.Post, "/invoke?name=worker")
         {
             Content = new StringContent("payload", Encoding.UTF8, "text/plain")
@@ -67,9 +67,7 @@ public class WorkerHttpForwardingTests
 
         Activity activity = await activityRecorder.WaitForActivityAsync();
         AssertRequestActivity(activity, "POST", "/invoke");
-        Assert.Equal(
-            WorkerHttpForwardingTelemetry.SuccessResult,
-            activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
+        Assert.Null(activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
         Assert.Null(activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
     }
@@ -102,7 +100,7 @@ public class WorkerHttpForwardingTests
     {
         await using WorkerProxyWebApplicationFactory factory = new();
         using HttpClient client = factory.CreateHttpForwardingClient();
-        using RequestActivityRecorder activityRecorder = new();
+        using RequestActivityRecorder activityRecorder = new("/");
 
         using HttpResponseMessage response = await client.GetAsync("/");
 
@@ -134,7 +132,7 @@ public class WorkerHttpForwardingTests
         };
         await using WorkerProxyWebApplicationFactory factory = new(configuration);
         using HttpClient client = factory.CreateHttpForwardingClient();
-        using RequestActivityRecorder activityRecorder = new();
+        using RequestActivityRecorder activityRecorder = new("/not-ready");
 
         using HttpResponseMessage response = await client.GetAsync("/not-ready");
 
@@ -173,7 +171,7 @@ public class WorkerHttpForwardingTests
         }
 
         await worker.StopAsync();
-        using RequestActivityRecorder activityRecorder = new();
+        using RequestActivityRecorder activityRecorder = new("/forwarding-failure");
 
         using HttpResponseMessage failedResponse = await client.GetAsync("/forwarding-failure");
 
@@ -281,7 +279,7 @@ public class WorkerHttpForwardingTests
 
         private readonly ActivityListener _listener;
 
-        public RequestActivityRecorder()
+        public RequestActivityRecorder(string requestPath)
         {
             _listener = new ActivityListener
             {
@@ -293,7 +291,10 @@ public class WorkerHttpForwardingTests
                     ActivitySamplingResult.AllDataAndRecorded,
                 ActivityStopped = activity =>
                 {
-                    if (activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute) is not null)
+                    if (string.Equals(
+                        activity.GetTagItem("url.path") as string,
+                        requestPath,
+                        StringComparison.Ordinal))
                     {
                         _completion.TrySetResult(activity);
                     }

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -140,7 +140,7 @@ public class WorkerHttpForwardingTests
             WorkerHttpForwardingTelemetry.DestinationNotReadyResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
         Assert.Equal(
-            WorkerHttpForwardingTelemetry.TimeoutError,
+            WorkerEndpointReadinessResult.Timeout.ToString(),
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwarderErrorAttribute));
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -112,7 +112,7 @@ public class WorkerHttpForwardingTests
             WorkerHttpForwardingTelemetry.DestinationNotConfiguredResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
         Assert.Equal(
-            WorkerHttpForwardingTelemetry.DestinationNotConfiguredErrorType,
+            StatusCodes.Status503ServiceUnavailable.ToString(),
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
@@ -144,7 +144,7 @@ public class WorkerHttpForwardingTests
             WorkerHttpForwardingTelemetry.DestinationNotReadyResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
         Assert.Equal(
-            WorkerHttpForwardingTelemetry.DestinationNotReadyErrorType,
+            StatusCodes.Status503ServiceUnavailable.ToString(),
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
@@ -183,8 +183,11 @@ public class WorkerHttpForwardingTests
             WorkerHttpForwardingTelemetry.ForwarderErrorResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
         Assert.Equal(
-            $"{WorkerHttpForwardingTelemetry.ForwarderErrorTypePrefix}Request",
+            StatusCodes.Status502BadGateway.ToString(),
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ErrorTypeAttribute));
+        Assert.Equal(
+            Yarp.ReverseProxy.Forwarder.ForwarderError.Request.ToString(),
+            activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwarderErrorAttribute));
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
 

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -139,9 +139,14 @@ public class WorkerHttpForwardingTests
         Assert.Equal(
             WorkerHttpForwardingTelemetry.DestinationNotReadyResult,
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
-        Assert.Equal(
-            WorkerEndpointReadinessResult.Timeout.ToString(),
+        string readinessError = Assert.IsType<string>(
             activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwarderErrorAttribute));
+        Assert.Contains(
+            readinessError,
+            [
+                WorkerEndpointReadinessResult.ConnectionRefused.ToString(),
+                WorkerEndpointReadinessResult.Timeout.ToString()
+            ]);
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
 


### PR DESCRIPTION
## Summary

- enriches the existing ASP.NET Core inbound request Activity only when forwarding fails, without creating a nested span or duplicating framework-owned HTTP attributes
- records stable, low-cardinality WorkerProxy forwarding outcomes and causes for unavailable destinations and YARP forwarding failures
- preserves the original incoming trace context when forwarding to the worker instead of propagating the proxy's outbound HTTP Activity
- leaves successful forwarding and caller cancellation unenriched; lack of an explicit failure remains the default success signal

This PR follows the now-merged #11991 and targets `dev`.

## Telemetry behavior

The existing inbound request span receives `azure.functions.worker_proxy.http.forwarding.result` only for these failures:

- `DestinationNotConfigured` for a 503 when no worker HTTP destination is advertised
- `DestinationNotReady` for a 503 when the advertised destination does not become ready
- `ForwarderError` whenever YARP reports a forwarding failure; the middleware sets 502 when the response has not started

`azure.functions.worker_proxy.http.forwarding.error` adds a bounded cause when available. Readiness failures use the `WorkerEndpointReadinessResult` value (`NameResolutionFailed`, `ConnectionRefused`, `Timeout`, or `ConnectionFailed`); YARP failures use the `ForwarderError` value such as `Request`. Failure spans are marked with `ActivityStatusCode.Error`, including failures after a response has started, because forwarding did not complete successfully even when the response status can no longer be changed to 502.

This layer does not set `error.type`; consistent HTTP-wide handling can be addressed separately. Existing semantic HTTP request and response attributes remain owned by ASP.NET Core, YARP, and System.Net.Http instrumentation.

## Trace propagation

The forwarder's `SocketsHttpHandler` sets `ActivityHeadersPropagator = null`. YARP continues copying the incoming tracing headers through to the worker, while System.Net.Http does not replace them with the proxy's outbound client Activity context. The worker's server span therefore remains parented by the original runtime context rather than the proxy.

## Validation

- `dotnet test test\Functions.WorkerProxy.Tests\Functions.WorkerProxy.Tests.csproj --configuration Release --filter "FullyQualifiedName~WorkerHttpForwardingTests|FullyQualifiedName~WorkerEndpointReadinessProbeTests" -p:TreatWarningsAsErrors=true --no-restore` (13 passed)
- `dotnet test test\Functions.WorkerProxy.Tests\Functions.WorkerProxy.Tests.csproj --configuration Release -p:TreatWarningsAsErrors=true --no-restore` (52 passed)
- `dotnet publish src\Functions.WorkerProxy\Functions.WorkerProxy.csproj --configuration Release --runtime win-x64 -p:TreatWarningsAsErrors=true -p:IlcUseEnvironmentalTools=true --no-restore` (Windows x64 Native AOT publish succeeded)