### PR TITLE
fixing test flake in FileWriter test

### DIFF
--- a/src/WebJobs.Script/Diagnostics/FileWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         // create a new log file
                         // we include a machine identifier in the log file name to ensure we don't have any
                         // log file contention between scaled out instances
-                        string filePath = Path.Combine(_logFilePath, GetFileName(DateTime.UtcNow, _instanceId));
+                        string filePath = Path.Combine(_logFilePath, GetFileName(_instanceId));
                         _currentLogFileInfo = new FileInfo(filePath);
                         _currentLogFileInfo.Create().Close();
                         newLogFileCreated = true;
@@ -291,9 +291,9 @@ namespace Microsoft.Azure.WebJobs.Script
             return instanceId.ToLowerInvariant();
         }
 
-        internal static string GetFileName(DateTime timestamp, string instanceId)
+        internal static string GetFileName(string instanceId)
         {
-            return $"{timestamp:yyyy-MM-ddTHH-mm-ssK}-{instanceId}.log";
+            return $"{DateTime.UtcNow:yyyy-MM-ddTHH-mm-ssK}-{instanceId}.log";
         }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/FileWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileWriter.cs
@@ -218,8 +218,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         // create a new log file
                         // we include a machine identifier in the log file name to ensure we don't have any
                         // log file contention between scaled out instances
-                        var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH-mm-ssK");
-                        string filePath = Path.Combine(_logFilePath, $"{timestamp}-{_instanceId}.log");
+                        string filePath = Path.Combine(_logFilePath, GetFileName(DateTime.UtcNow, _instanceId));
                         _currentLogFileInfo = new FileInfo(filePath);
                         _currentLogFileInfo.Create().Close();
                         newLogFileCreated = true;
@@ -290,6 +289,11 @@ namespace Microsoft.Azure.WebJobs.Script
             instanceId = instanceId.Length > 10 ? instanceId.Substring(0, 10) : instanceId;
 
             return instanceId.ToLowerInvariant();
+        }
+
+        internal static string GetFileName(DateTime timestamp, string instanceId)
+        {
+            return $"{timestamp:yyyy-MM-ddTHH-mm-ssK}-{instanceId}.log";
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
@@ -246,9 +246,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             File.Delete(firstLogFile.FullName);
 
             // wait until the timestamp used in the filename has advanced
+            string instanceId = FileWriter.GetInstanceId();
             await TestHelpers.Await(() =>
             {
-                string currentLogFileName = FileWriter.GetFileName(DateTime.UtcNow, FileWriter.GetInstanceId());
+                string currentLogFileName = FileWriter.GetFileName(instanceId);
                 return !File.Exists(firstLogFile.FullName) &&
                     !string.Equals(firstLogFile.Name, currentLogFileName, StringComparison.Ordinal);
             });

--- a/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
@@ -245,9 +245,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // created
             File.Delete(firstLogFile.FullName);
 
-            // wait at least a second to ensure the file gets a distinct timestamp
-            await TestHelpers.Await(() => !File.Exists(firstLogFile.FullName));
-            await Task.Delay(1000);
+            // wait until the timestamp used in the filename has advanced
+            await TestHelpers.Await(() =>
+            {
+                string currentLogFileName = FileWriter.GetFileName(DateTime.UtcNow, FileWriter.GetInstanceId());
+                return !File.Exists(firstLogFile.FullName) &&
+                    !string.Equals(firstLogFile.Name, currentLogFileName, StringComparison.Ordinal);
+            });
 
             fileWriter.AppendLine("test trace");
             fileWriter.Flush();


### PR DESCRIPTION
Even though the test is explicitly waiting a second before continuing, timing issues in CI means this doesn't actually happen (the whole test took 900ms when this failed last...).

So instead of hardcoding a wait, we'll wait until the second actually rolls over by comparing what the new filename should be.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)