### PR TITLE
fix(worker-proxy): allow large forwarded requests

### DIFF
--- a/src/Functions.WorkerProxy/WorkerProxyApplication.cs
+++ b/src/Functions.WorkerProxy/WorkerProxyApplication.cs
@@ -82,35 +82,29 @@ internal static class WorkerProxyApplication
 
     private static void ConfigureHttpPipeline(IApplicationBuilder app)
     {
+        static Task UpdateMaxRequestBodySizeAsync(HttpContext context, RequestDelegate next)
+        {
+            // Allow unlimited request body size for requests forwarded to the worker. This is safe because the worker
+            // is trusted and the host will enforce its own limits on the request body size.
+            if (context.Features.Get<IHttpMaxRequestBodySizeFeature>() is { IsReadOnly: false } requestBodySizeFeature)
+            {
+                requestBodySizeFeature.MaxRequestBodySize = null;
+            }
+
+            return next(context);
+        }
+
+        static Task ForwardAsync(HttpContext context, WorkerHttpForwardingMiddleware middleware)
+            => middleware.InvokeAsync(context);
+
         app.UseRouting();
+        app.Use(UpdateMaxRequestBodySizeAsync);
         app.UseEndpoints(static endpoints =>
         {
             // Admin paths are reserved for the platform. We intentionally block them to make that clear.
             endpoints.Map("/admin/{**path}", static () => Results.NotFound()).AllowAnonymous();
-            endpoints.Map(
-                "/{**path}",
-                ForwardHttpRequestAsync)
-                .AllowAnonymous();
+            endpoints.Map("/{**path}", ForwardAsync).AllowAnonymous();
         });
-    }
-
-    private static Task ForwardHttpRequestAsync(
-        HttpContext context, WorkerHttpForwardingMiddleware middleware)
-    {
-        IHttpMaxRequestBodySizeFeature requestBodySizeFeature =
-            context.Features.Get<IHttpMaxRequestBodySizeFeature>()
-            ?? throw new InvalidOperationException(
-                "Unable to disable the forwarded request body size limit because IHttpMaxRequestBodySizeFeature is unavailable.");
-
-        if (requestBodySizeFeature.IsReadOnly)
-        {
-            throw new InvalidOperationException(
-                "Unable to disable the forwarded request body size limit after the request body has been read.");
-        }
-
-        requestBodySizeFeature.MaxRequestBodySize = null;
-
-        return middleware.InvokeAsync(context);
     }
 
     private static void ConfigureHttpForwarding(WebApplicationBuilder builder)

--- a/src/Functions.WorkerProxy/WorkerProxyApplication.cs
+++ b/src/Functions.WorkerProxy/WorkerProxyApplication.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Azure.Functions.WorkerProxy.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -87,9 +89,28 @@ internal static class WorkerProxyApplication
             endpoints.Map("/admin/{**path}", static () => Results.NotFound()).AllowAnonymous();
             endpoints.Map(
                 "/{**path}",
-                static (HttpContext context, WorkerHttpForwardingMiddleware middleware) => middleware.InvokeAsync(context))
+                ForwardHttpRequestAsync)
                 .AllowAnonymous();
         });
+    }
+
+    private static Task ForwardHttpRequestAsync(
+        HttpContext context, WorkerHttpForwardingMiddleware middleware)
+    {
+        IHttpMaxRequestBodySizeFeature requestBodySizeFeature =
+            context.Features.Get<IHttpMaxRequestBodySizeFeature>()
+            ?? throw new InvalidOperationException(
+                "Unable to disable the forwarded request body size limit because IHttpMaxRequestBodySizeFeature is unavailable.");
+
+        if (requestBodySizeFeature.IsReadOnly)
+        {
+            throw new InvalidOperationException(
+                "Unable to disable the forwarded request body size limit after the request body has been read.");
+        }
+
+        requestBodySizeFeature.MaxRequestBodySize = null;
+
+        return middleware.InvokeAsync(context);
     }
 
     private static void ConfigureHttpForwarding(WebApplicationBuilder builder)

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -26,6 +27,8 @@ namespace Azure.Functions.WorkerProxy.Tests;
 
 public class WorkerHttpForwardingTests
 {
+    private const long KestrelDefaultMaxRequestBodySize = 30_000_000;
+
     public static IEnumerable<object[]> ForwarderErrors =>
         Enum.GetValues<ForwarderError>()
             .Where(static error => error is not ForwarderError.None)
@@ -70,6 +73,48 @@ public class WorkerHttpForwardingTests
         AssertRequestActivity(activity, "POST", "/invoke");
         Assert.Null(activity.GetTagItem(WorkerHttpForwardingTelemetry.ForwardingResultAttribute));
         Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+    }
+
+    [Fact]
+    public async Task HttpListener_ForwardsBodyLargerThanKestrelDefaultLimit()
+    {
+        const long bodyLength = KestrelDefaultMaxRequestBodySize + 1;
+        await using WebApplication worker = await StartWorkerAsync(async context =>
+        {
+            byte[] buffer = new byte[16 * 1024];
+            long receivedLength = 0;
+            bool contentIsValid = true;
+            int read;
+            while ((read = await context.Request.Body.ReadAsync(buffer)) > 0)
+            {
+                contentIsValid &= buffer.AsSpan(0, read).IndexOfAnyExcept((byte)0x5a) < 0;
+                receivedLength += read;
+            }
+
+            context.Response.StatusCode = contentIsValid
+                ? StatusCodes.Status200OK
+                : StatusCodes.Status422UnprocessableEntity;
+            await context.Response.WriteAsync(receivedLength.ToString(CultureInfo.InvariantCulture));
+        }, allowUnlimitedRequestBody: true);
+        Dictionary<string, string?> configuration = new()
+        {
+            [$"{WorkerProxyOptions.SectionName}:{nameof(WorkerProxyOptions.WorkerHttpEndpoint)}"] =
+                GetAddress(worker).AbsoluteUri
+        };
+        await using WorkerProxyWebApplicationFactory factory = new(configuration);
+        using HttpClient client = factory.CreateHttpForwardingClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, "/large-body")
+        {
+            Content = new RepeatedByteContent(bodyLength, 0x5a)
+        };
+        using CancellationTokenSource timeout = new(TimeSpan.FromMinutes(1));
+
+        using HttpResponseMessage response = await client.SendAsync(request, timeout.Token);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(
+            bodyLength.ToString(CultureInfo.InvariantCulture),
+            await response.Content.ReadAsStringAsync(timeout.Token));
     }
 
     [Fact]
@@ -377,10 +422,18 @@ public class WorkerHttpForwardingTests
         Assert.Equal(0, requestCount);
     }
 
-    private static async Task<WebApplication> StartWorkerAsync(RequestDelegate handler, int port = 0)
+    private static async Task<WebApplication> StartWorkerAsync(
+        RequestDelegate handler, int port = 0, bool allowUnlimitedRequestBody = false)
     {
         WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
-        builder.WebHost.UseKestrel(options => options.Listen(IPAddress.Loopback, port));
+        builder.WebHost.UseKestrel(options =>
+        {
+            options.Listen(IPAddress.Loopback, port);
+            if (allowUnlimitedRequestBody)
+            {
+                options.Limits.MaxRequestBodySize = null;
+            }
+        });
         WebApplication app = builder.Build();
         app.Run(handler);
         await app.StartAsync();
@@ -476,6 +529,34 @@ public class WorkerHttpForwardingTests
             }
 
             return error;
+        }
+    }
+
+    private sealed class RepeatedByteContent(long length, byte value) : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            return SerializeToStreamAsync(stream, context, CancellationToken.None);
+        }
+
+        protected override async Task SerializeToStreamAsync(
+            Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[16 * 1024];
+            Array.Fill(buffer, value);
+            long remaining = length;
+            while (remaining > 0)
+            {
+                int count = (int)Math.Min(remaining, buffer.Length);
+                await stream.WriteAsync(buffer.AsMemory(0, count), cancellationToken);
+                remaining -= count;
+            }
+        }
+
+        protected override bool TryComputeLength(out long computedLength)
+        {
+            computedLength = length;
+            return true;
         }
     }
 }

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpForwardingTests.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Yarp.ReverseProxy.Forwarder;
@@ -115,6 +116,40 @@ public class WorkerHttpForwardingTests
         Assert.Equal(
             bodyLength.ToString(CultureInfo.InvariantCulture),
             await response.Content.ReadAsStringAsync(timeout.Token));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task HttpListener_RequestBodySizeLimitCannotBeDisabled_StillForwards(bool featureAvailable)
+    {
+        await using WebApplication worker = await StartWorkerAsync(async context =>
+        {
+            string requestBody = await new StreamReader(context.Request.Body).ReadToEndAsync();
+            context.Response.StatusCode = StatusCodes.Status201Created;
+            await context.Response.WriteAsync(requestBody);
+        });
+        Dictionary<string, string?> configuration = new()
+        {
+            [$"{WorkerProxyOptions.SectionName}:{nameof(WorkerProxyOptions.WorkerHttpEndpoint)}"] =
+                GetAddress(worker).AbsoluteUri
+        };
+        IHttpMaxRequestBodySizeFeature? feature = featureAvailable
+            ? new ReadOnlyRequestBodySizeFeature()
+            : null;
+        await using WorkerProxyWebApplicationFactory factory = new(
+            configuration,
+            services => services.AddSingleton<IStartupFilter>(new RequestBodySizeFeatureStartupFilter(feature)));
+        using HttpClient client = factory.CreateHttpForwardingClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, "/invoke")
+        {
+            Content = new StringContent("payload", Encoding.UTF8, "text/plain")
+        };
+
+        using HttpResponseMessage response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal("payload", await response.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -557,6 +592,33 @@ public class WorkerHttpForwardingTests
         {
             computedLength = length;
             return true;
+        }
+    }
+
+    private sealed class RequestBodySizeFeatureStartupFilter(IHttpMaxRequestBodySizeFeature? feature) : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return app =>
+            {
+                app.Use(async (context, nextMiddleware) =>
+                {
+                    context.Features.Set(feature);
+                    await nextMiddleware(context);
+                });
+                next(app);
+            };
+        }
+    }
+
+    private sealed class ReadOnlyRequestBodySizeFeature : IHttpMaxRequestBodySizeFeature
+    {
+        public bool IsReadOnly => true;
+
+        public long? MaxRequestBodySize
+        {
+            get => KestrelDefaultMaxRequestBodySize;
+            set => throw new InvalidOperationException("The request body size limit is read-only.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- adds the new top layer above #11998
- removes Kestrel's request-body ceiling in inline middleware placed immediately after routing on the dedicated WorkerProxy HTTP listener branch
- applies the override best-effort when `IHttpMaxRequestBodySizeFeature` is available and writable
- leaves the management readiness listener and both gRPC listeners unchanged
- keeps request-limit ownership with the destination worker rather than imposing a WorkerProxy ceiling

## Context
Addresses the #11991 review concern: "HTTP forwarding is capped at Kestrel’s default 30,000,000-byte body limit, which breaks larger requests and surfaces as 502."

ASP.NET Core 10 defaults Kestrel's `MaxRequestBodySize` to exactly 30,000,000 bytes. The HTTP listener pipeline sets the per-request `IHttpMaxRequestBodySizeFeature.MaxRequestBodySize` to `null` after `UseRouting()` and before endpoint execution, so YARP can stream the request body without a WorkerProxy-imposed ceiling. If the feature is unavailable or already read-only, forwarding proceeds without changing it. The destination worker remains responsible for its own application/request limit.

The reserved `/admin/*` endpoint retains its existing 404 routing behavior; it does not consume request bodies. A bounded-memory integration test streams 30,000,001 deterministic bytes through the HTTP/1 proxy listener, and the destination validates and counts the body before returning the received length. Before the fix, the same test was rejected by Kestrel and the client connection closed during upload.

## Validation
- `dotnet test test\Functions.WorkerProxy.Tests\Functions.WorkerProxy.Tests.csproj -c Release --no-restore --property:TreatWarningsAsErrors=true --nologo` (77 passed)
- `dotnet publish src\Functions.WorkerProxy\Functions.WorkerProxy.csproj -c Release -r win-x64 --self-contained true --no-restore --property:TreatWarningsAsErrors=true --nologo` (Native AOT publish succeeded)