### PR TITLE
Add RPC client invocation dispatcher

### DIFF
--- a/src/Functions.Rpc.Client/Dispatcher/IRpcClientFunctionInvocationDispatcher.cs
+++ b/src/Functions.Rpc.Client/Dispatcher/IRpcClientFunctionInvocationDispatcher.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Workers;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Dispatches function invocations through client-backed worker channels.
+/// </summary>
+public interface IRpcClientFunctionInvocationDispatcher : IFunctionInvocationDispatcher
+{
+    /// <summary>
+    /// Sets up invocation buffers and sends function load requests to a newly linked channel.
+    /// </summary>
+    /// <param name="channel">The newly linked channel.</param>
+    /// <returns>A task that completes after invocation buffers are initialized.</returns>
+    Task SetupChannelAsync(WorkerChannel channel);
+}

--- a/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcher.cs
+++ b/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcher.cs
@@ -1,0 +1,345 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.Azure.WebJobs.Host.Executors.Internal;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Dispatches function invocations through client-backed worker channels.
+/// </summary>
+/// <remarks>
+/// One dispatcher belongs to a ScriptHost child container. It borrows root-owned channels and never disposes them.
+/// </remarks>
+internal sealed partial class RpcClientFunctionInvocationDispatcher : IRpcClientFunctionInvocationDispatcher
+{
+    private static readonly TimeSpan DefaultChannelWaitTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly IWorkerChannelRegistry _channelRegistry;
+    private readonly CancellationTokenSource _dispatcherStoppedSource = new();
+    private readonly ILogger<RpcClientFunctionInvocationDispatcher> _logger;
+    private readonly ManagedDependencyOptions _managedDependencyOptions;
+    private readonly TimeSpan _channelWaitTimeout;
+    private readonly Lock _stateLock = new();
+    private readonly ScriptJobHostOptions _scriptHostOptions;
+    private IReadOnlyList<FunctionMetadata> _functions = [];
+    private int _nextChannelIndex = -1;
+    private bool _disposed;
+    private bool _stopping;
+
+    public RpcClientFunctionInvocationDispatcher(
+        IWorkerChannelRegistry channelRegistry,
+        IOptions<ScriptJobHostOptions> scriptHostOptions,
+        IOptions<ManagedDependencyOptions> managedDependencyOptions,
+        ILogger<RpcClientFunctionInvocationDispatcher> logger)
+        : this(channelRegistry, scriptHostOptions, managedDependencyOptions, logger, DefaultChannelWaitTimeout)
+    {
+    }
+
+    internal RpcClientFunctionInvocationDispatcher(
+        IWorkerChannelRegistry channelRegistry,
+        IOptions<ScriptJobHostOptions> scriptHostOptions,
+        IOptions<ManagedDependencyOptions> managedDependencyOptions,
+        ILogger<RpcClientFunctionInvocationDispatcher> logger,
+        TimeSpan channelWaitTimeout)
+    {
+        _channelRegistry = channelRegistry ?? throw new ArgumentNullException(nameof(channelRegistry));
+        _scriptHostOptions = scriptHostOptions?.Value ?? throw new ArgumentNullException(nameof(scriptHostOptions));
+        _managedDependencyOptions = managedDependencyOptions?.Value ?? throw new ArgumentNullException(nameof(managedDependencyOptions));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        if (channelWaitTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channelWaitTimeout), "The channel wait timeout must be greater than zero.");
+        }
+
+        _channelWaitTimeout = channelWaitTimeout;
+    }
+
+    public FunctionInvocationDispatcherState State { get; private set; }
+
+    public int ErrorEventsThreshold => 3;
+
+    public Task InvokeAsync(ScriptInvocationContext invocationContext)
+    {
+        ArgumentNullException.ThrowIfNull(invocationContext);
+
+        // Keep the common path synchronous and allocation-free after the registry snapshot.
+        WorkerChannel channel = GetReadyChannel();
+        return channel is null
+            ? InvokeWhenChannelIsReadyAsync(invocationContext)
+            : DispatchInvocation(invocationContext, channel);
+    }
+
+    public Task SetupChannelAsync(WorkerChannel channel)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_stopping)
+        {
+            throw new InvalidOperationException("The invocation dispatcher is stopping.");
+        }
+
+        if (State is FunctionInvocationDispatcherState.Default)
+        {
+            throw new InvalidOperationException("The invocation dispatcher has not been initialized.");
+        }
+
+        // Invocation buffers accept work while the worker completes its function-load responses.
+        channel.SetupFunctionInvocationBuffers(_functions);
+        channel.SendFunctionLoadRequests(_managedDependencyOptions, _scriptHostOptions.FunctionTimeout);
+        return channel.InvocationBuffersInitialization;
+    }
+
+    private Task DispatchInvocation(ScriptInvocationContext invocationContext, WorkerChannel channel)
+    {
+        using FunctionInvoker.Scope scope = FunctionInvoker.BeginSystemScope();
+        string functionId = invocationContext.FunctionMetadata.GetFunctionId();
+        if (channel.FunctionInputBuffers.TryGetValue(functionId, out BufferBlock<ScriptInvocationContext> inputBuffer))
+        {
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                Log.PostingInvocation(_logger, invocationContext.ExecutionContext.InvocationId, channel.Id);
+            }
+
+            inputBuffer.Post(invocationContext);
+            return Task.CompletedTask;
+        }
+
+        throw new InvalidOperationException(
+            $"Function '{invocationContext.FunctionMetadata.Name}' is not loaded by worker '{channel.Id}'.");
+    }
+
+    public async Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        FunctionMetadata[] functionArray = functions?.ToArray() ?? [];
+
+        if (functionArray.Length == 0)
+        {
+            Log.NoFunctions(_logger, nameof(RpcClientFunctionInvocationDispatcher));
+            return;
+        }
+
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_stopping)
+        {
+            throw new InvalidOperationException("The invocation dispatcher is stopping.");
+        }
+
+        State = FunctionInvocationDispatcherState.Initializing;
+        _functions = functionArray;
+
+        // Metadata is available before this lifecycle callback, so eagerly load every worker linked during startup.
+        IReadOnlyList<WorkerChannel> channels = _channelRegistry.GetInitializedChannels();
+        List<Task> channelSetupTasks = [];
+        foreach (WorkerChannel channel in channels)
+        {
+            try
+            {
+                channelSetupTasks.Add(SetupChannelAsync(channel));
+            }
+            catch (Exception exception)
+            {
+                Log.ChannelSetupFailed(_logger, exception, channel.Id);
+                channelSetupTasks.Add(Task.FromException(exception));
+            }
+        }
+
+        try
+        {
+            await Task.WhenAll(channelSetupTasks).WaitAsync(cancellationToken);
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested && channels.Any(IsReadyForInvocations))
+        {
+            // A failed channel must not prevent startup when another linked channel can serve invocations.
+        }
+
+        AddLogUserCategory(functionArray);
+        State = FunctionInvocationDispatcherState.Initialized;
+    }
+
+    public async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
+    {
+        // Preserve snapshot order so each status remains paired with the channel that produced it.
+        IReadOnlyList<WorkerChannel> channels = _channelRegistry.GetInitializedChannels();
+        WorkerStatus[] statuses = await Task.WhenAll(channels.Select(channel => channel.GetWorkerStatusAsync()));
+
+        Dictionary<string, WorkerStatus> result = new(StringComparer.Ordinal);
+        for (int i = 0; i < channels.Count; i++)
+        {
+            result.Add(channels[i].Id, statuses[i]);
+        }
+
+        return result;
+    }
+
+    public async Task ShutdownAsync()
+    {
+        PreShutdown();
+
+        // The registry owns channel disposal; the dispatcher only gives accepted invocations time to drain.
+        Task[] drainTasks = [.. _channelRegistry.GetInitializedChannels()
+            .Where(channel => channel.IsChannelReadyForInvocations())
+            .Select(channel => channel.DrainInvocationsAsync())];
+
+        try
+        {
+            await Task.WhenAll(drainTasks).WaitAsync(DefaultShutdownTimeout);
+        }
+        catch (TimeoutException)
+        {
+            Log.DrainTimedOut(_logger);
+        }
+    }
+
+    public Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception)
+        => Task.FromResult(false);
+
+    public Task StartWorkerChannel() => Task.CompletedTask;
+
+    public void PreShutdown()
+    {
+        bool stop;
+        lock (_stateLock)
+        {
+            // This latch is best effort. A ready-channel invocation racing shutdown may still be accepted and drained.
+            stop = !_disposed && !_stopping;
+            if (stop)
+            {
+                _stopping = true;
+                State = FunctionInvocationDispatcherState.Disposing;
+            }
+        }
+
+        if (stop)
+        {
+            _dispatcherStoppedSource.Cancel();
+        }
+    }
+
+    public void Dispose()
+    {
+        bool dispose;
+        lock (_stateLock)
+        {
+            dispose = !_disposed;
+            if (dispose)
+            {
+                _disposed = true;
+                _stopping = true;
+                State = FunctionInvocationDispatcherState.Disposed;
+            }
+        }
+
+        if (dispose)
+        {
+            _dispatcherStoppedSource.Cancel();
+        }
+    }
+
+    private WorkerChannel GetReadyChannel()
+    {
+        IReadOnlyList<WorkerChannel> channels = _channelRegistry.GetInitializedChannels();
+        if (channels.Count == 0)
+        {
+            return null;
+        }
+
+        if (channels.Count == 1)
+        {
+            // The common one-worker path avoids round-robin synchronization and scanning.
+            WorkerChannel channel = channels[0];
+            return IsReadyForInvocations(channel) ? channel : null;
+        }
+
+        // Start each scan at the next channel to spread work without allocating or locking.
+        int startIndex = (int)((uint)Interlocked.Increment(ref _nextChannelIndex) % (uint)channels.Count);
+        for (int offset = 0; offset < channels.Count; offset++)
+        {
+            WorkerChannel channel = channels[(startIndex + offset) % channels.Count];
+            if (IsReadyForInvocations(channel))
+            {
+                return channel;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task InvokeWhenChannelIsReadyAsync(ScriptInvocationContext invocationContext)
+    {
+        // Lifecycle checks and cancellation linking stay off the ready-channel hot path.
+        if (_stopping)
+        {
+            throw new InvalidOperationException("The invocation dispatcher is stopping.");
+        }
+
+        if (State is not FunctionInvocationDispatcherState.Initialized)
+        {
+            throw new InvalidOperationException("The invocation dispatcher has not been initialized.");
+        }
+
+        using CancellationTokenSource operationSource =
+            CancellationTokenSource.CreateLinkedTokenSource(invocationContext.CancellationToken, _dispatcherStoppedSource.Token);
+        operationSource.CancelAfter(_channelWaitTimeout);
+        try
+        {
+            WorkerChannel initializedChannel = await _channelRegistry.WaitForFirstInitializedAsync(operationSource.Token)
+                .WaitAsync(operationSource.Token);
+            await initializedChannel.InvocationBuffersInitialization.WaitAsync(operationSource.Token);
+        }
+        catch (OperationCanceledException) when (!invocationContext.CancellationToken.IsCancellationRequested &&
+            !_dispatcherStoppedSource.IsCancellationRequested)
+        {
+            throw new TimeoutException($"No client-backed worker channel became ready within {_channelWaitTimeout}.");
+        }
+
+        // Linking publishes an initialized channel; the coordinator must finish SetupChannelAsync before it is selectable.
+        WorkerChannel channel = GetReadyChannel()
+            ?? throw new InvalidOperationException("No client-backed worker channel is ready for invocations.");
+        await DispatchInvocation(invocationContext, channel);
+    }
+
+    private static bool IsReadyForInvocations(WorkerChannel channel) => channel.IsChannelReadyForInvocations();
+
+    private void AddLogUserCategory(IEnumerable<FunctionMetadata> functions)
+    {
+        foreach (FunctionMetadata metadata in functions)
+        {
+            metadata.Properties[LogConstants.CategoryNameKey] = LogCategories.CreateFunctionUserCategory(metadata.Name);
+            metadata.Properties[ScriptConstants.LogPropertyHostInstanceIdKey] = _scriptHostOptions.InstanceId;
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Trace, "Posting invocation {InvocationId} on worker {WorkerId}.")]
+        public static partial void PostingInvocation(ILogger logger, Guid invocationId, string workerId);
+
+        [LoggerMessage(1, LogLevel.Debug, "{Dispatcher} received no functions.")]
+        public static partial void NoFunctions(ILogger logger, string dispatcher);
+
+        [LoggerMessage(2, LogLevel.Debug, "Draining client-backed worker invocations timed out during dispatcher shutdown.")]
+        public static partial void DrainTimedOut(ILogger logger);
+
+        [LoggerMessage(3, LogLevel.Warning, "Failed to configure client-backed worker {WorkerId} for invocations.")]
+        public static partial void ChannelSetupFailed(ILogger logger, Exception exception, string workerId);
+    }
+}

--- a/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcher.cs
+++ b/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcher.cs
@@ -36,7 +36,6 @@ internal sealed partial class RpcClientFunctionInvocationDispatcher : IRpcClient
     private readonly ILogger<RpcClientFunctionInvocationDispatcher> _logger;
     private readonly ManagedDependencyOptions _managedDependencyOptions;
     private readonly TimeSpan _channelWaitTimeout;
-    private readonly Lock _stateLock = new();
     private readonly ScriptJobHostOptions _scriptHostOptions;
     private IReadOnlyList<FunctionMetadata> _functions = [];
     private int _nextChannelIndex = -1;
@@ -143,8 +142,8 @@ internal sealed partial class RpcClientFunctionInvocationDispatcher : IRpcClient
             throw new InvalidOperationException("The invocation dispatcher is stopping.");
         }
 
-        State = FunctionInvocationDispatcherState.Initializing;
         _functions = functionArray;
+        State = FunctionInvocationDispatcherState.Initializing;
 
         // Metadata is available before this lifecycle callback, so eagerly load every worker linked during startup.
         IReadOnlyList<WorkerChannel> channels = _channelRegistry.GetInitializedChannels();
@@ -172,7 +171,10 @@ internal sealed partial class RpcClientFunctionInvocationDispatcher : IRpcClient
         }
 
         AddLogUserCategory(functionArray);
-        State = FunctionInvocationDispatcherState.Initialized;
+        if (!_disposed && !_stopping)
+        {
+            State = FunctionInvocationDispatcherState.Initialized;
+        }
     }
 
     public async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
@@ -216,42 +218,28 @@ internal sealed partial class RpcClientFunctionInvocationDispatcher : IRpcClient
 
     public void PreShutdown()
     {
-        bool stop;
-        lock (_stateLock)
+        if (_disposed || _stopping)
         {
-            // This latch is best effort. A ready-channel invocation racing shutdown may still be accepted and drained.
-            stop = !_disposed && !_stopping;
-            if (stop)
-            {
-                _stopping = true;
-                State = FunctionInvocationDispatcherState.Disposing;
-            }
+            return;
         }
 
-        if (stop)
-        {
-            _dispatcherStoppedSource.Cancel();
-        }
+        // This latch is best effort. A ready-channel invocation racing shutdown may still be accepted and drained.
+        _stopping = true;
+        State = FunctionInvocationDispatcherState.Disposing;
+        _dispatcherStoppedSource.Cancel();
     }
 
     public void Dispose()
     {
-        bool dispose;
-        lock (_stateLock)
+        if (_disposed)
         {
-            dispose = !_disposed;
-            if (dispose)
-            {
-                _disposed = true;
-                _stopping = true;
-                State = FunctionInvocationDispatcherState.Disposed;
-            }
+            return;
         }
 
-        if (dispose)
-        {
-            _dispatcherStoppedSource.Cancel();
-        }
+        _disposed = true;
+        _stopping = true;
+        State = FunctionInvocationDispatcherState.Disposed;
+        _dispatcherStoppedSource.Cancel();
     }
 
     private WorkerChannel GetReadyChannel()

--- a/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcher.cs
+++ b/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcher.cs
@@ -78,6 +78,11 @@ internal sealed partial class RpcClientFunctionInvocationDispatcher : IRpcClient
     public Task InvokeAsync(ScriptInvocationContext invocationContext)
     {
         ArgumentNullException.ThrowIfNull(invocationContext);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_stopping)
+        {
+            throw new InvalidOperationException("The invocation dispatcher is stopping.");
+        }
 
         // Keep the common path synchronous and allocation-free after the registry snapshot.
         WorkerChannel channel = GetReadyChannel();
@@ -273,12 +278,7 @@ internal sealed partial class RpcClientFunctionInvocationDispatcher : IRpcClient
 
     private async Task InvokeWhenChannelIsReadyAsync(ScriptInvocationContext invocationContext)
     {
-        // Lifecycle checks and cancellation linking stay off the ready-channel hot path.
-        if (_stopping)
-        {
-            throw new InvalidOperationException("The invocation dispatcher is stopping.");
-        }
-
+        // Initialization checks and cancellation linking stay off the ready-channel hot path.
         if (State is not FunctionInvocationDispatcherState.Initialized)
         {
             throw new InvalidOperationException("The invocation dispatcher has not been initialized.");

--- a/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcherFactory.cs
+++ b/src/Functions.Rpc.Client/Dispatcher/RpcClientFunctionInvocationDispatcherFactory.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Workers;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Provides the invocation dispatcher for client-backed workers.
+/// </summary>
+internal sealed class RpcClientFunctionInvocationDispatcherFactory(
+    IRpcClientFunctionInvocationDispatcher dispatcher) : IFunctionInvocationDispatcherFactory
+{
+    private readonly IRpcClientFunctionInvocationDispatcher _dispatcher =
+        dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+
+    public IFunctionInvocationDispatcher GetFunctionDispatcher() => _dispatcher;
+}

--- a/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
+++ b/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -11,7 +12,7 @@ namespace Azure.Functions.Rpc.Client;
 /// <summary>
 /// Registers the Client transport and channel lifecycle for isolated tests.
 /// </summary>
-/// <remarks>Production composition must remain absent until the later compute composition milestone.</remarks>
+/// <remarks>Production composition must remain absent until compute composition explicitly consumes these registrations.</remarks>
 internal static class RpcClientServiceCollectionExtensions
 {
     /// <summary>
@@ -27,6 +28,21 @@ internal static class RpcClientServiceCollectionExtensions
         services.TryAddSingleton<IDuplexChannelFactory<StreamingMessage>, FunctionRpcDuplexChannelFactory>();
         services.TryAddSingleton<IRpcClientWorkerChannelFactory, RpcClientWorkerChannelFactory>();
         services.TryAddSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds Client services owned by one ScriptHost child container.
+    /// </summary>
+    /// <param name="services">The service collection to update.</param>
+    /// <returns>The supplied service collection.</returns>
+    internal static IServiceCollection AddRpcClientScriptHostServices(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IRpcClientFunctionInvocationDispatcher, RpcClientFunctionInvocationDispatcher>();
+        services.TryAddSingleton<IFunctionInvocationDispatcherFactory, RpcClientFunctionInvocationDispatcherFactory>();
 
         return services;
     }

--- a/src/Functions.Rpc.Client/Registry/WorkerChannelRegistry.cs
+++ b/src/Functions.Rpc.Client/Registry/WorkerChannelRegistry.cs
@@ -355,6 +355,15 @@ internal sealed partial class WorkerChannelRegistry : IWorkerChannelRegistry
 
                 try
                 {
+                    removedChannel.Shutdown(terminalException);
+                }
+                catch (Exception exception)
+                {
+                    Log.ChannelShutdownFailed(_logger, exception, workerId);
+                }
+
+                try
+                {
                     await removedChannel.DisposeAsync();
                 }
                 catch (Exception exception)
@@ -451,5 +460,8 @@ internal sealed partial class WorkerChannelRegistry : IWorkerChannelRegistry
 
         [LoggerMessage(3, LogLevel.Error, "Failed to remove the completed FunctionRpc channel for worker {WorkerId}.")]
         public static partial void ChannelRemovalFailed(ILogger logger, Exception exception, string workerId);
+
+        [LoggerMessage(4, LogLevel.Error, "Failed to shut down the completed FunctionRpc channel for worker {WorkerId}.")]
+        public static partial void ChannelShutdownFailed(ILogger logger, Exception exception, string workerId);
     }
 }

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -72,6 +72,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private readonly string _workerInvocationFailedMetric;
         private readonly IAppCapabilitiesStore _appCapabilitiesStore;
         private readonly DuplexChannel<StreamingMessage> _ownedChannel;
+        private readonly TaskCompletionSource _invocationBuffersInitialized =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         private Task _disposeTask;
         private RpcWorkerChannelState _state;
         private TaskCompletionSource<bool> _workerInitTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -194,6 +197,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         /// Gets the current script job host options.
         /// </summary>
         public IOptions<ScriptJobHostOptions> JobHostOptions => _scriptHostOptions;
+
+        /// <summary>
+        /// Gets a task that completes after invocation buffers are initialized.
+        /// </summary>
+        public Task InvocationBuffersInitialization => _invocationBuffersInitialized.Task;
 
         internal bool IsSharedMemoryDataTransferEnabled => _isSharedMemoryDataTransferEnabled;
 
@@ -678,6 +686,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 _functionInputBuffers[functionId] = new BufferBlock<ScriptInvocationContext>();
             }
             _state |= RpcWorkerChannelState.InvocationBuffersInitialized;
+            _invocationBuffersInitialized.TrySetResult();
         }
 
         /// <inheritdoc />

--- a/src/WebJobs.Script.Grpc/FunctionInvocationDispatcherState.cs
+++ b/src/WebJobs.Script.Grpc/FunctionInvocationDispatcherState.cs
@@ -3,10 +3,13 @@
 
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
-    internal enum FunctionInvocationDispatcherState
+    /// <summary>
+    /// Describes the lifecycle state of an invocation dispatcher.
+    /// </summary>
+    public enum FunctionInvocationDispatcherState
     {
         /// <summary>
-        /// The FunctionDispatcher has not yet been created
+        /// The FunctionDispatcher has not yet been created.
         /// </summary>
         Default,
 
@@ -28,12 +31,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         WorkerProcessRestarting,
 
         /// <summary>
-        /// The FunctionDispatcher is disposing
+        /// The FunctionDispatcher is disposing.
         /// </summary>
         Disposing,
 
         /// <summary>
-        /// The FunctionDispatcher is disposed
+        /// The FunctionDispatcher is disposed.
         /// </summary>
         Disposed
     }

--- a/src/WebJobs.Script.Grpc/IFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/IFunctionInvocationDispatcher.cs
@@ -9,24 +9,65 @@ using Microsoft.Azure.WebJobs.Script.Description;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
-    internal interface IFunctionInvocationDispatcher : IDisposable
+    /// <summary>
+    /// Dispatches function invocations to a configured worker topology.
+    /// </summary>
+    public interface IFunctionInvocationDispatcher : IDisposable
     {
+        /// <summary>
+        /// Gets the current dispatcher state.
+        /// </summary>
         FunctionInvocationDispatcherState State { get; }
 
+        /// <summary>
+        /// Gets the worker error threshold used by host monitoring.
+        /// </summary>
         int ErrorEventsThreshold { get; }
 
+        /// <summary>
+        /// Dispatches an invocation to an eligible worker.
+        /// </summary>
+        /// <param name="invocationContext">The invocation to dispatch.</param>
+        /// <returns>A task that completes when the invocation is accepted for dispatch.</returns>
         Task InvokeAsync(ScriptInvocationContext invocationContext);
 
+        /// <summary>
+        /// Initializes the dispatcher for the supplied functions.
+        /// </summary>
+        /// <param name="functions">The indexed functions.</param>
+        /// <param name="cancellationToken">A token that cancels initialization.</param>
+        /// <returns>A task that completes when dispatcher initialization finishes.</returns>
         Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Gets the current status of each worker.
+        /// </summary>
+        /// <returns>A task that produces worker status keyed by worker ID.</returns>
         Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync();
 
+        /// <summary>
+        /// Waits for active invocations to finish during shutdown.
+        /// </summary>
+        /// <returns>A task that completes when shutdown draining finishes.</returns>
         Task ShutdownAsync();
 
+        /// <summary>
+        /// Restarts the worker executing an invocation when supported by the topology.
+        /// </summary>
+        /// <param name="invocationId">The invocation identifier.</param>
+        /// <param name="exception">The failure that prompted the restart.</param>
+        /// <returns>A task that produces <see langword="true"/> when a worker was restarted.</returns>
         Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception);
 
+        /// <summary>
+        /// Starts another worker channel when supported by the topology.
+        /// </summary>
+        /// <returns>A task that completes when the channel-start operation finishes.</returns>
         Task StartWorkerChannel();
 
+        /// <summary>
+        /// Prevents new work before dispatcher shutdown begins.
+        /// </summary>
         void PreShutdown();
     }
 }

--- a/src/WebJobs.Script.Grpc/IFunctionInvocationDispatcherFactory.cs
+++ b/src/WebJobs.Script.Grpc/IFunctionInvocationDispatcherFactory.cs
@@ -3,8 +3,15 @@
 
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
-    internal interface IFunctionInvocationDispatcherFactory
+    /// <summary>
+    /// Provides the invocation dispatcher selected by the worker topology.
+    /// </summary>
+    public interface IFunctionInvocationDispatcherFactory
     {
+        /// <summary>
+        /// Gets the selected invocation dispatcher.
+        /// </summary>
+        /// <returns>The selected dispatcher.</returns>
         IFunctionInvocationDispatcher GetFunctionDispatcher();
     }
 }

--- a/test/Functions.Rpc.Client.Tests/Dispatcher/RpcClientFunctionInvocationDispatcherTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Dispatcher/RpcClientFunctionInvocationDispatcherTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+public sealed class RpcClientFunctionInvocationDispatcherTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+    private readonly List<WorkerChannel> _channels = [];
+    private readonly Mock<IWorkerChannelRegistry> _registry = new();
+
+    public RpcClientFunctionInvocationDispatcherTests()
+    {
+        _registry.Setup(registry => registry.GetInitializedChannels())
+            .Returns(() => [.. _channels]);
+        _registry.Setup(registry => registry.WaitForFirstInitializedAsync(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken cancellationToken) => WaitForChannelAsync(cancellationToken));
+        _registry.Setup(registry => registry.UnlinkAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ConfiguresInitializedChannels()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+
+        Task initialization = dispatcher.InitializeAsync([function]);
+        StreamingMessage request = await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionLoadRequest);
+        await initialization.WaitAsync(TestTimeout);
+        Assert.True(worker.Channel.InvocationBuffersInitialization.IsCompletedSuccessfully);
+        await worker.SendFunctionLoadResponseAsync(function.GetFunctionId());
+
+        Assert.Equal(FunctionInvocationDispatcherState.Initialized, dispatcher.State);
+        Assert.Equal(function.GetFunctionId(), request.FunctionLoadRequest.FunctionId);
+        Assert.True(worker.Channel.FunctionInputBuffers.ContainsKey(function.GetFunctionId()));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_CompletesSuccessfulInvocation()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        ScriptInvocationContext invocation = CreateInvocation(function);
+
+        await InitializeDispatcherAsync(dispatcher, function, worker);
+        await dispatcher.InvokeAsync(invocation);
+        StreamingMessage request = await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+        await worker.SendInvocationResponseAsync(request.InvocationRequest.InvocationId);
+
+        ScriptInvocationResult result = await invocation.ResultSource.Task.WaitAsync(TestTimeout);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SurfacesFunctionLoadFailure()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        ScriptInvocationContext invocation = CreateInvocation(function);
+
+        Task initialization = dispatcher.InitializeAsync([function]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionLoadRequest);
+        await worker.SendFunctionLoadResponseAsync(function.GetFunctionId(), succeeded: false);
+        await initialization.WaitAsync(TestTimeout);
+        await dispatcher.InvokeAsync(invocation);
+
+        Exception exception = await Assert.ThrowsAnyAsync<Exception>(() => invocation.ResultSource.Task.WaitAsync(TestTimeout));
+        Assert.Contains("function load failed", exception.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PropagatesInvocationCancellation()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        using CancellationTokenSource cancellationSource = new();
+        ScriptInvocationContext invocation = CreateInvocation(function, cancellationSource.Token);
+
+        await InitializeDispatcherAsync(dispatcher, function, worker);
+        cancellationSource.Cancel();
+        await dispatcher.InvokeAsync(invocation);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invocation.ResultSource.Task.WaitAsync(TestTimeout));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WaitsForFirstInitializedChannel()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        ScriptInvocationContext invocation = CreateInvocation(function);
+
+        await dispatcher.InitializeAsync([function]);
+        Task invoke = dispatcher.InvokeAsync(invocation);
+        Assert.False(invoke.IsCompleted);
+
+        _channels.Add(worker.Channel);
+        Task setup = dispatcher.SetupChannelAsync(worker.Channel);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionLoadRequest);
+        Assert.True(setup.IsCompletedSuccessfully);
+        await setup.WaitAsync(TestTimeout);
+        await invoke.WaitAsync(TestTimeout);
+
+        await worker.SendFunctionLoadResponseAsync(function.GetFunctionId());
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_CancellationWhileWaitingIsCallerVisible()
+    {
+        using CancellationTokenSource cancellationSource = new();
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        ScriptInvocationContext invocation = CreateInvocation(function, cancellationSource.Token);
+        await dispatcher.InitializeAsync([function]);
+
+        Task invoke = dispatcher.InvokeAsync(invocation);
+        cancellationSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => invoke.WaitAsync(TestTimeout));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoInitializedChannelTimesOut()
+    {
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher(TimeSpan.FromMilliseconds(50));
+        FunctionMetadata function = CreateFunction();
+        ScriptInvocationContext invocation = CreateInvocation(function);
+        await dispatcher.InitializeAsync([function]);
+
+        TimeoutException exception = await Assert.ThrowsAsync<TimeoutException>(() => dispatcher.InvokeAsync(invocation).WaitAsync(TestTimeout));
+
+        Assert.Contains("No client-backed worker channel became ready", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SelectsReadyChannelsRoundRobin()
+    {
+        await using ClientWorkerChannelTestHarness first = await ClientWorkerChannelTestHarness.CreateAsync("a-worker");
+        await using ClientWorkerChannelTestHarness second = await ClientWorkerChannelTestHarness.CreateAsync("b-worker");
+        _channels.Add(second.Channel);
+        _channels.Add(first.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        await InitializeDispatcherAsync(dispatcher, function, first, second);
+
+        await dispatcher.InvokeAsync(CreateInvocation(function));
+        await dispatcher.InvokeAsync(CreateInvocation(function));
+
+        await first.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+        await second.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ReadyChannelUsesSingleRegistrySnapshot()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        await InitializeDispatcherAsync(dispatcher, function, worker);
+        _registry.Invocations.Clear();
+
+        await dispatcher.InvokeAsync(CreateInvocation(function));
+
+        _registry.Verify(registry => registry.GetInitializedChannels(), Times.Once);
+        _registry.Verify(registry => registry.WaitForFirstInitializedAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _registry.Verify(registry => registry.UnlinkAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SetupChannelAsync_CompletesWhenInvocationBuffersAreInitialized()
+    {
+        await using ClientWorkerChannelTestHarness first = await ClientWorkerChannelTestHarness.CreateAsync("a-worker");
+        await using ClientWorkerChannelTestHarness second = await ClientWorkerChannelTestHarness.CreateAsync("b-worker");
+        _channels.Add(first.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        await InitializeDispatcherAsync(dispatcher, function, first);
+
+        _channels.Add(second.Channel);
+        Task setup = dispatcher.SetupChannelAsync(second.Channel);
+        await second.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionLoadRequest);
+        await setup.WaitAsync(TestTimeout);
+        Assert.True(second.Channel.InvocationBuffersInitialization.IsCompletedSuccessfully);
+
+        await second.SendFunctionLoadResponseAsync(function.GetFunctionId());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ChannelFailureDoesNotPreventLaterDispatch()
+    {
+        await using ClientWorkerChannelTestHarness failed = await ClientWorkerChannelTestHarness.CreateAsync("a-worker");
+        await using ClientWorkerChannelTestHarness healthy = await ClientWorkerChannelTestHarness.CreateAsync("b-worker");
+        _channels.Add(failed.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        ScriptInvocationContext failedInvocation = CreateInvocation(function);
+        await InitializeDispatcherAsync(dispatcher, function, failed);
+        await dispatcher.InvokeAsync(failedInvocation);
+        await failed.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+
+        failed.Transport.CompleteResponses(new InvalidOperationException("transport failed"));
+        await Assert.ThrowsAnyAsync<Exception>(() => failedInvocation.ResultSource.Task.WaitAsync(TestTimeout));
+        _channels.Clear();
+        _channels.Add(healthy.Channel);
+        Task setup = dispatcher.SetupChannelAsync(healthy.Channel);
+        await healthy.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionLoadRequest);
+        await healthy.SendFunctionLoadResponseAsync(function.GetFunctionId());
+        await setup.WaitAsync(TestTimeout);
+
+        await dispatcher.InvokeAsync(CreateInvocation(function));
+
+        await healthy.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+    }
+
+    [Fact]
+    public async Task GetWorkerStatusesAsync_NoInitializedChannelsReturnsEmpty()
+    {
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+
+        IDictionary<string, WorkerStatus> statuses = await dispatcher.GetWorkerStatusesAsync();
+
+        Assert.Empty(statuses);
+    }
+
+    [Fact]
+    public void Factory_ReturnsRegisteredDispatcher()
+    {
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        RpcClientFunctionInvocationDispatcherFactory factory = new(dispatcher);
+
+        IFunctionInvocationDispatcher first = factory.GetFunctionDispatcher();
+        IFunctionInvocationDispatcher second = factory.GetFunctionDispatcher();
+
+        Assert.Same(first, second);
+        Assert.Same(dispatcher, first);
+    }
+
+    [Fact]
+    public async Task Dispose_AllowsBestEffortDispatchWithoutDisposingChannel()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        await InitializeDispatcherAsync(dispatcher, function, worker);
+
+        dispatcher.Dispose();
+
+        await dispatcher.InvokeAsync(CreateInvocation(function));
+
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+        Assert.Equal(FunctionInvocationDispatcherState.Disposed, dispatcher.State);
+        Assert.Equal(0, worker.Transport.DisposeCount);
+    }
+
+    [Fact]
+    public async Task PreShutdown_RejectsNewInvocations()
+    {
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        await dispatcher.InitializeAsync([function]);
+
+        dispatcher.PreShutdown();
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.InvokeAsync(CreateInvocation(function)));
+        Assert.Contains("stopping", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(FunctionInvocationDispatcherState.Disposing, dispatcher.State);
+    }
+
+    private RpcClientFunctionInvocationDispatcher CreateDispatcher(TimeSpan? channelWaitTimeout = null)
+        => new(
+            _registry.Object,
+            Options.Create(new ScriptJobHostOptions()),
+            Options.Create(new ManagedDependencyOptions()),
+            NullLogger<RpcClientFunctionInvocationDispatcher>.Instance,
+            channelWaitTimeout ?? TimeSpan.FromSeconds(10));
+
+    private async Task<WorkerChannel> WaitForChannelAsync(CancellationToken cancellationToken)
+    {
+        while (_channels.Count == 0)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
+        }
+
+        return _channels[0];
+    }
+
+    private static async Task InitializeDispatcherAsync(
+        RpcClientFunctionInvocationDispatcher dispatcher,
+        FunctionMetadata function,
+        params ClientWorkerChannelTestHarness[] workers)
+    {
+        Task initialization = dispatcher.InitializeAsync([function]);
+        foreach (ClientWorkerChannelTestHarness worker in workers)
+        {
+            await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionLoadRequest);
+            await worker.SendFunctionLoadResponseAsync(function.GetFunctionId());
+        }
+
+        await initialization.WaitAsync(TestTimeout);
+    }
+
+    private static FunctionMetadata CreateFunction()
+    {
+        FunctionMetadata function = new()
+        {
+            Language = "external",
+            Name = "TestFunction",
+        };
+        return function;
+    }
+
+    private static ScriptInvocationContext CreateInvocation(FunctionMetadata function, CancellationToken cancellationToken = default)
+        => new()
+        {
+            FunctionMetadata = function,
+            ExecutionContext = new()
+            {
+                FunctionName = function.Name,
+                InvocationId = Guid.NewGuid(),
+            },
+            BindingData = [],
+            Inputs = [],
+            ResultSource = new(TaskCreationOptions.RunContinuationsAsynchronously),
+            CancellationToken = cancellationToken,
+            AsyncExecutionContext = System.Threading.ExecutionContext.Capture(),
+            Logger = NullLogger.Instance,
+        };
+}

--- a/test/Functions.Rpc.Client.Tests/Dispatcher/RpcClientFunctionInvocationDispatcherTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Dispatcher/RpcClientFunctionInvocationDispatcherTests.cs
@@ -213,6 +213,23 @@ public sealed class RpcClientFunctionInvocationDispatcherTests
     }
 
     [Fact]
+    public async Task SetupChannelAsync_AfterPreShutdownDoesNotConfigureChannel()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        await dispatcher.InitializeAsync([function]);
+        dispatcher.PreShutdown();
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.SetupChannelAsync(worker.Channel));
+
+        Assert.Contains("stopping", exception.Message, StringComparison.Ordinal);
+        Assert.False(worker.Channel.InvocationBuffersInitialization.IsCompleted);
+        Assert.Empty(worker.Channel.FunctionInputBuffers);
+    }
+
+    [Fact]
     public async Task InvokeAsync_ChannelFailureDoesNotPreventLaterDispatch()
     {
         await using ClientWorkerChannelTestHarness failed = await ClientWorkerChannelTestHarness.CreateAsync("a-worker");

--- a/test/Functions.Rpc.Client.Tests/Dispatcher/RpcClientFunctionInvocationDispatcherTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Dispatcher/RpcClientFunctionInvocationDispatcherTests.cs
@@ -280,21 +280,45 @@ public sealed class RpcClientFunctionInvocationDispatcherTests
     }
 
     [Fact]
-    public async Task Dispose_AllowsBestEffortDispatchWithoutDisposingChannel()
+    public async Task Dispose_RejectsNewInvocationsWithoutDisposingChannel()
     {
         await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
         _channels.Add(worker.Channel);
-        RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
         FunctionMetadata function = CreateFunction();
         await InitializeDispatcherAsync(dispatcher, function, worker);
+        _registry.Invocations.Clear();
 
         dispatcher.Dispose();
 
-        await dispatcher.InvokeAsync(CreateInvocation(function));
+        ObjectDisposedException exception = await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => dispatcher.InvokeAsync(CreateInvocation(function)));
 
-        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.InvocationRequest);
+        Assert.Equal(typeof(RpcClientFunctionInvocationDispatcher).FullName, exception.ObjectName);
         Assert.Equal(FunctionInvocationDispatcherState.Disposed, dispatcher.State);
         Assert.Equal(0, worker.Transport.DisposeCount);
+        _registry.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task PreShutdown_WithReadyChannelRejectsNewInvocations()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
+        FunctionMetadata function = CreateFunction();
+        await InitializeDispatcherAsync(dispatcher, function, worker);
+        _registry.Invocations.Clear();
+
+        dispatcher.PreShutdown();
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.InvokeAsync(CreateInvocation(function)));
+
+        Assert.Contains("stopping", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(FunctionInvocationDispatcherState.Disposing, dispatcher.State);
+        Assert.Equal(0, worker.Transport.DisposeCount);
+        _registry.VerifyNoOtherCalls();
     }
 
     [Fact]
@@ -303,6 +327,7 @@ public sealed class RpcClientFunctionInvocationDispatcherTests
         using RpcClientFunctionInvocationDispatcher dispatcher = CreateDispatcher();
         FunctionMetadata function = CreateFunction();
         await dispatcher.InitializeAsync([function]);
+        _registry.Invocations.Clear();
 
         dispatcher.PreShutdown();
 
@@ -310,6 +335,7 @@ public sealed class RpcClientFunctionInvocationDispatcherTests
             () => dispatcher.InvokeAsync(CreateInvocation(function)));
         Assert.Contains("stopping", exception.Message, StringComparison.Ordinal);
         Assert.Equal(FunctionInvocationDispatcherState.Disposing, dispatcher.State);
+        _registry.VerifyNoOtherCalls();
     }
 
     private RpcClientFunctionInvocationDispatcher CreateDispatcher(TimeSpan? channelWaitTimeout = null)

--- a/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -23,6 +24,19 @@ public sealed class RpcClientServiceCollectionExtensionsTests
         AssertSingleton<IDuplexChannelFactory<StreamingMessage>, FunctionRpcDuplexChannelFactory>(services);
         AssertSingleton<IRpcClientWorkerChannelFactory, RpcClientWorkerChannelFactory>(services);
         AssertSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>(services);
+    }
+
+    [Fact]
+    public void AddRpcClientScriptHostServices_RegistersDispatcherFactoryAsSingleton()
+    {
+        ServiceCollection services = new();
+
+        IServiceCollection result = services.AddRpcClientScriptHostServices();
+        services.AddRpcClientScriptHostServices();
+
+        Assert.Same(services, result);
+        AssertSingleton<IRpcClientFunctionInvocationDispatcher, RpcClientFunctionInvocationDispatcher>(services);
+        AssertSingleton<IFunctionInvocationDispatcherFactory, RpcClientFunctionInvocationDispatcherFactory>(services);
     }
 
     private static void AssertSingleton<TService, TImplementation>(IServiceCollection services)

--- a/test/Functions.Rpc.Client.Tests/Registry/WorkerChannelRegistryTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Registry/WorkerChannelRegistryTests.cs
@@ -247,7 +247,7 @@ public sealed class WorkerChannelRegistryTests
         Assert.False(registry.TryGetInitializedChannel("first", out _));
         Assert.True(registry.TryGetInitializedChannel("second", out WorkerChannel healthyChannel));
         Assert.Same(second.Channel, healthyChannel);
-        WorkerChannel relinkedChannel = await LinkAsync(registry, "first");
+        WorkerChannel relinkedChannel = await LinkWhenAvailableAsync(registry, "first");
         Assert.Same(replacement.Channel, relinkedChannel);
     }
 
@@ -380,6 +380,23 @@ public sealed class WorkerChannelRegistryTests
 
     private static Task<WorkerChannel> LinkAsync(WorkerChannelRegistry registry, string workerId)
         => registry.LinkAsync(workerId, CreateEndpoint(workerId));
+
+    private static async Task<WorkerChannel> LinkWhenAvailableAsync(WorkerChannelRegistry registry, string workerId)
+    {
+        using CancellationTokenSource timeoutSource = new(TestTimeout);
+        while (true)
+        {
+            try
+            {
+                return await registry.LinkAsync(workerId, CreateEndpoint(workerId), timeoutSource.Token);
+            }
+            catch (InvalidOperationException exception)
+                when (string.Equals(exception.Message, $"Worker '{workerId}' is already linked.", StringComparison.Ordinal))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10), timeoutSource.Token);
+            }
+        }
+    }
 
     private static Uri CreateEndpoint(string workerId)
         => new($"http://{workerId}.test:5000");

--- a/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
+++ b/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Xunit;
 
 namespace Azure.Functions.Rpc.Client.Tests;
@@ -48,6 +49,19 @@ public class RpcClientAssemblyTests
         Assert.True(typeof(WorkerChannel).IsPublic);
         Assert.Equal(typeof(WorkerChannel), typeof(RpcClientWorkerChannel).BaseType);
         Assert.Equal("Azure.Functions.Rpc.Client", typeof(RpcClientWorkerChannel).Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void ClientDispatcherUsesPublicSharedContracts()
+    {
+        Assert.True(typeof(IFunctionInvocationDispatcher).IsPublic);
+        Assert.True(typeof(IFunctionInvocationDispatcherFactory).IsPublic);
+        Assert.True(typeof(FunctionInvocationDispatcherState).IsPublic);
+        Assert.True(typeof(IRpcClientFunctionInvocationDispatcher).IsPublic);
+        Assert.Contains(typeof(IFunctionInvocationDispatcher),
+            typeof(RpcClientFunctionInvocationDispatcher).GetInterfaces());
+        Assert.Contains(typeof(IRpcClientFunctionInvocationDispatcher),
+            typeof(RpcClientFunctionInvocationDispatcher).GetInterfaces());
     }
 
     [Fact]

--- a/test/Functions.Rpc.Client.Tests/WorkerChannel/ClientWorkerChannelTestHarness.cs
+++ b/test/Functions.Rpc.Client.Tests/WorkerChannel/ClientWorkerChannelTestHarness.cs
@@ -1,0 +1,148 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.AppCapabilities;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+internal sealed class ClientWorkerChannelTestHarness : IAsyncDisposable
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
+    private ClientWorkerChannelTestHarness(RpcClientWorkerChannel channel, TestDuplexChannel<StreamingMessage> transport)
+    {
+        Channel = channel;
+        Transport = transport;
+    }
+
+    internal RpcClientWorkerChannel Channel { get; }
+
+    internal TestDuplexChannel<StreamingMessage> Transport { get; }
+
+    internal static async Task<ClientWorkerChannelTestHarness> CreateAsync(string workerId)
+    {
+        TestDuplexChannel<StreamingMessage> transport = new();
+        RpcClientWorkerChannel channel = CreateFactory().Create(workerId, transport);
+        Task start = channel.StartAsync(CancellationToken.None);
+
+        await transport.SendResponseAsync(new()
+        {
+            StartStream = new() { WorkerId = workerId },
+        });
+
+        StreamingMessage initRequest = await transport.Requests.ReadAsync().AsTask().WaitAsync(TestTimeout);
+        if (initRequest.ContentCase is not StreamingMessage.ContentOneofCase.WorkerInitRequest)
+        {
+            throw new InvalidOperationException($"Expected a worker init request, but received {initRequest.ContentCase}.");
+        }
+
+        await transport.SendResponseAsync(new()
+        {
+            WorkerInitResponse = new()
+            {
+                Result = new() { Status = StatusResult.Types.Status.Success },
+            },
+        });
+        await start.WaitAsync(TestTimeout);
+
+        return new(channel, transport);
+    }
+
+    internal async Task<StreamingMessage> ReadRequestAsync(StreamingMessage.ContentOneofCase contentCase)
+    {
+        StreamingMessage request = await Transport.Requests.ReadAsync().AsTask().WaitAsync(TestTimeout);
+        if (request.ContentCase != contentCase)
+        {
+            throw new InvalidOperationException($"Expected {contentCase}, but received {request.ContentCase}.");
+        }
+
+        return request;
+    }
+
+    internal ValueTask SendFunctionLoadResponseAsync(string functionId, bool succeeded = true)
+        => Transport.SendResponseAsync(new()
+        {
+            FunctionLoadResponse = new()
+            {
+                FunctionId = functionId,
+                Result = new()
+                {
+                    Status = succeeded ? StatusResult.Types.Status.Success : StatusResult.Types.Status.Failure,
+                    Exception = succeeded ? null : new() { Message = "function load failed" },
+                },
+            },
+        });
+
+    internal ValueTask SendInvocationResponseAsync(string invocationId, bool succeeded = true)
+        => Transport.SendResponseAsync(new()
+        {
+            InvocationResponse = new()
+            {
+                InvocationId = invocationId,
+                Result = new()
+                {
+                    Status = succeeded ? StatusResult.Types.Status.Success : StatusResult.Types.Status.Failure,
+                    Exception = succeeded ? null : new() { Message = "invocation failed" },
+                },
+            },
+        });
+
+    internal ValueTask SendFunctionMetadataResponseAsync(
+        IEnumerable<RpcFunctionMetadata> functions = null,
+        bool useDefaultMetadataIndexing = false)
+    {
+        FunctionMetadataResponse response = new()
+        {
+            Result = new() { Status = StatusResult.Types.Status.Success },
+            UseDefaultMetadataIndexing = useDefaultMetadataIndexing,
+        };
+        response.FunctionMetadataResults.Add(functions ?? Enumerable.Empty<RpcFunctionMetadata>());
+
+        return Transport.SendResponseAsync(new() { FunctionMetadataResponse = response });
+    }
+
+    public ValueTask DisposeAsync() => Channel.DisposeAsync();
+
+    private static RpcClientWorkerChannelFactory CreateFactory()
+    {
+        Mock<IScriptHostManager> hostManager = new();
+        hostManager.As<IServiceProvider>()
+            .Setup(provider => provider.GetService(typeof(IOptions<ScriptJobHostOptions>)))
+            .Returns(Options.Create(new ScriptJobHostOptions { RootScriptPath = "c:\\test" }));
+        Mock<IOptionsMonitor<ScriptApplicationHostOptions>> applicationHostOptions = new();
+        applicationHostOptions.SetupGet(options => options.CurrentValue)
+            .Returns(new ScriptApplicationHostOptions { ScriptPath = "c:\\test" });
+        Mock<IAppCapabilitiesStore> appCapabilitiesStore = new();
+        appCapabilitiesStore.Setup(store => store.TrySetAll(It.IsAny<IEnumerable<KeyValuePair<string, string>>>()))
+            .Returns(true);
+
+        return new(
+            new ScriptEventManager(),
+            hostManager.Object,
+            Mock.Of<IEnvironment>(),
+            NullLoggerFactory.Instance,
+            applicationHostOptions.Object,
+            Mock.Of<ISharedMemoryManager>(),
+            Options.Create(new WorkerConcurrencyOptions()),
+            Options.Create(new FunctionsHostingConfigOptions()),
+            appCapabilitiesStore.Object,
+            Mock.Of<IHttpProxyService>(),
+            Mock.Of<IMetricsLogger>());
+    }
+}


### PR DESCRIPTION
Adds a Client-owned invocation dispatcher that eagerly prepares linked workers and routes invocations without introducing Server process semantics or production composition.

The dispatcher reuses the shared `WorkerChannel` invocation pipeline, exposes an explicit setup seam for newly linked workers, and keeps the ready-channel invocation path minimal. Client services remain reachable only through the test registration helper; compute composition is separate follow-up work.

### Issue describing the changes in this PR

resolves #11981

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

This is the bottom PR in a two-PR stack. The Client metadata provider will target this branch.