### PR TITLE
Add RPC client metadata provider

### DIFF
--- a/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
+++ b/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,6 +44,7 @@ internal static class RpcClientServiceCollectionExtensions
 
         services.TryAddSingleton<IRpcClientFunctionInvocationDispatcher, RpcClientFunctionInvocationDispatcher>();
         services.TryAddSingleton<IFunctionInvocationDispatcherFactory, RpcClientFunctionInvocationDispatcherFactory>();
+        services.TryAddSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>();
 
         return services;
     }

--- a/src/Functions.Rpc.Client/Metadata/RpcClientWorkerFunctionMetadataProvider.cs
+++ b/src/Functions.Rpc.Client/Metadata/RpcClientWorkerFunctionMetadataProvider.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Retrieves and validates function metadata from a client-backed worker channel.
+/// </summary>
+/// <remarks>
+/// One provider belongs to a ScriptHost child container so its metadata cache is replaced on host restart. The provider
+/// borrows the root-owned registry and requests registry cleanup when a metadata operation makes a channel unusable.
+/// </remarks>
+internal sealed partial class RpcClientWorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider
+{
+    private const string MetadataProviderName = "RpcClient";
+    private static readonly TimeSpan DefaultChannelWaitTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly IWorkerChannelRegistry _channelRegistry;
+    private readonly TimeSpan _channelWaitTimeout;
+    private readonly ILogger<RpcClientWorkerFunctionMetadataProvider> _logger;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private readonly WorkerFunctionMetadataValidator _validator;
+    private FunctionMetadataResult _cachedResult;
+
+    public RpcClientWorkerFunctionMetadataProvider(
+        IWorkerChannelRegistry channelRegistry,
+        ILogger<RpcClientWorkerFunctionMetadataProvider> logger,
+        IWorkerRuntimeResolver workerRuntimeResolver)
+        : this(channelRegistry, logger, workerRuntimeResolver, DefaultChannelWaitTimeout)
+    {
+    }
+
+    internal RpcClientWorkerFunctionMetadataProvider(
+        IWorkerChannelRegistry channelRegistry,
+        ILogger<RpcClientWorkerFunctionMetadataProvider> logger,
+        IWorkerRuntimeResolver workerRuntimeResolver,
+        TimeSpan channelWaitTimeout)
+    {
+        _channelRegistry = channelRegistry ?? throw new ArgumentNullException(nameof(channelRegistry));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _validator = new(logger, workerRuntimeResolver ?? throw new ArgumentNullException(nameof(workerRuntimeResolver)));
+
+        if (channelWaitTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(channelWaitTimeout), "The channel wait timeout must be greater than zero.");
+        }
+
+        _channelWaitTimeout = channelWaitTimeout;
+    }
+
+    public ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors => _validator.FunctionErrors;
+
+    public async Task<FunctionMetadataResult> GetFunctionMetadataAsync(
+        IEnumerable<RpcWorkerConfig> workerConfigs,
+        bool forceRefresh = false)
+    {
+        using SemaphoreLock refreshLock = await _refreshLock.LockAsync();
+        if (!forceRefresh && _cachedResult is not null)
+        {
+            return _cachedResult;
+        }
+
+        Log.ReadingMetadata(_logger, MetadataProviderName);
+        WorkerChannel channel = await GetInitializedChannelAsync();
+        Log.FetchingMetadata(_logger, channel.Id);
+        List<RawFunctionMetadata> rawFunctions;
+        try
+        {
+            rawFunctions = await channel.GetFunctionMetadata().WaitAsync(_channelWaitTimeout);
+        }
+        catch (Exception exception)
+        {
+            try
+            {
+                await _channelRegistry.UnlinkAsync(channel.Id);
+            }
+            catch (Exception unlinkException)
+            {
+                throw new AggregateException("Function metadata failed and the worker channel could not be unlinked.",
+                    exception, unlinkException);
+            }
+
+            ExceptionDispatchInfo.Capture(exception).Throw();
+            throw;
+        }
+
+        if (rawFunctions.Any(metadata => metadata.UseDefaultMetadataIndexing))
+        {
+            throw new InvalidOperationException(
+                "Client-backed workers must provide function metadata and cannot request host metadata indexing.");
+        }
+
+        ImmutableArray<FunctionMetadata> functions = _validator.ValidateMetadata(rawFunctions);
+        Log.FunctionsReturned(_logger, functions.Length, MetadataProviderName);
+        _cachedResult = new(useDefaultMetadataIndexing: false, functions);
+        return _cachedResult;
+    }
+
+    private async Task<WorkerChannel> GetInitializedChannelAsync()
+    {
+        WorkerChannel channel = _channelRegistry.GetInitializedChannels()
+            .OrderBy(channel => channel.Id, StringComparer.Ordinal)
+            .FirstOrDefault();
+        if (channel is not null)
+        {
+            return channel;
+        }
+
+        using CancellationTokenSource timeoutSource = new(_channelWaitTimeout);
+        try
+        {
+            return await _channelRegistry.WaitForFirstInitializedAsync(timeoutSource.Token);
+        }
+        catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+        {
+            throw new TimeoutException($"No client-backed worker channel initialized within {_channelWaitTimeout}.");
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Debug, "Fetching function metadata from client-backed worker {WorkerId}.")]
+        public static partial void FetchingMetadata(ILogger logger, string workerId);
+
+        [LoggerMessage(1, LogLevel.Information, "Reading functions metadata ({Provider}).")]
+        public static partial void ReadingMetadata(ILogger logger, string provider);
+
+        [LoggerMessage(2, LogLevel.Information, "{Count} functions returned by metadata provider {Provider}.")]
+        public static partial void FunctionsReturned(ILogger logger, int count, string provider);
+    }
+}

--- a/src/Functions.Rpc.Client/Metadata/RpcClientWorkerFunctionMetadataProvider.cs
+++ b/src/Functions.Rpc.Client/Metadata/RpcClientWorkerFunctionMetadataProvider.cs
@@ -80,7 +80,7 @@ internal sealed partial class RpcClientWorkerFunctionMetadataProvider : IWorkerF
         List<RawFunctionMetadata> rawFunctions;
         try
         {
-            rawFunctions = await channel.GetFunctionMetadata().WaitAsync(_channelWaitTimeout);
+            rawFunctions = await channel.GetFunctionMetadata();
         }
         catch (Exception exception)
         {

--- a/src/Functions.Rpc.Client/WorkerChannel/RpcClientWorkerChannel.cs
+++ b/src/Functions.Rpc.Client/WorkerChannel/RpcClientWorkerChannel.cs
@@ -115,11 +115,21 @@ internal sealed class RpcClientWorkerChannel : WorkerChannel
         return _startCompletion.Task.WaitAsync(cancellationToken);
     }
 
+    protected override void OnMetadataRequestError(Exception exception) => FailPendingMetadataRequest(exception);
+
+    protected override void OnChannelFailure(Exception exception) => FailPendingMetadataRequest(exception);
+
     protected override void Dispose(bool disposing)
     {
         lock (_lifecycleLock)
         {
             _lifecycleState = LifecycleState.Disposed;
+        }
+
+        if (disposing)
+        {
+            // Metadata callers did not request cancellation; fail so host startup can retry.
+            FailPendingMetadataRequest(new ObjectDisposedException(GetType().FullName));
         }
 
         base.Dispose(disposing);

--- a/src/Functions.Rpc.Server/WorkerFunctionMetadataProvider.cs
+++ b/src/Functions.Rpc.Server/WorkerFunctionMetadataProvider.cs
@@ -9,26 +9,25 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
     internal class WorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider, IDisposable
     {
         private const string _metadataProviderName = "Worker";
-        private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _scriptOptions;
         private readonly ILogger _logger;
         private readonly IEnvironment _environment;
         private readonly IWebHostRpcWorkerChannelManager _channelManager;
         private readonly IScriptHostManager _scriptHostManager;
+        private readonly WorkerFunctionMetadataValidator _metadataValidator;
         private readonly IWorkerRuntimeResolver _workerRuntimeResolver;
         private string _workerRuntime;
         private ImmutableArray<FunctionMetadata> _functions;
@@ -48,13 +47,14 @@ namespace Microsoft.Azure.WebJobs.Script
             _channelManager = webHostRpcWorkerChannelManager;
             _scriptHostManager = scriptHostManager;
             _workerRuntimeResolver = workerRuntimeResolver;
+            _metadataValidator = new(logger, workerRuntimeResolver);
             _workerRuntime = workerRuntimeResolver.GetWorkerRuntime();
 
             _scriptHostManager.ActiveHostChanged += OnHostChanged;
         }
 
         public ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors
-            => _functionErrors.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
+            => _metadataValidator.FunctionErrors;
 
         public async Task<FunctionMetadataResult> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, bool forceRefresh)
         {
@@ -235,110 +235,10 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         internal IEnumerable<FunctionMetadata> ValidateMetadata(IEnumerable<RawFunctionMetadata> functions)
-        {
-            List<FunctionMetadata> validatedMetadata = new List<FunctionMetadata>();
-            if (IsNullOrEmpty(functions))
-            {
-                _logger.LogDebug("There is no metadata to be validated.");
-                return validatedMetadata;
-            }
-            _functionErrors.Clear();
-            foreach (RawFunctionMetadata rawFunction in functions)
-            {
-                var function = rawFunction.Metadata;
-                try
-                {
-                    Utility.ValidateName(function.Name);
-
-                    function.Language = _workerRuntimeResolver.GetWorkerRuntime();
-
-                    // skip function directory validation because this involves reading function.json
-
-                    // skip function ScriptFile validation for now because this involves enumerating file directory
-
-                    // configuration source validation
-                    if (!string.IsNullOrEmpty(rawFunction.ConfigurationSource))
-                    {
-                        JToken isDirect = JToken.Parse(rawFunction.ConfigurationSource);
-                        var isDirectValue = isDirect?.ToString();
-                        if (string.Equals(isDirectValue, "attributes", StringComparison.OrdinalIgnoreCase))
-                        {
-                            function.SetIsDirect(true);
-                        }
-                        else if (!string.Equals(isDirectValue, "config", StringComparison.OrdinalIgnoreCase))
-                        {
-                            throw new FormatException($"Illegal value '{isDirectValue}' for 'configurationSource' property in {function.Name}'.");
-                        }
-                    }
-
-                    // populate retry options if json string representation is provided
-                    if (!string.IsNullOrEmpty(rawFunction.RetryOptions))
-                    {
-                        function.Retry = JObject.Parse(rawFunction.RetryOptions).ToObject<RetryOptions>();
-                    }
-
-                    // retry option validation
-                    if (function.Retry is not null)
-                    {
-                        Utility.ValidateRetryOptions(function.Retry);
-                    }
-
-                    // binding validation
-                    function = ValidateBindings(rawFunction.Bindings, function);
-
-                    // add validated metadata to validated list if it gets this far
-                    validatedMetadata.Add(function);
-                }
-                catch (Exception ex)
-                {
-                    Utility.AddFunctionError(_functionErrors, function.Name, Utility.FlattenException(ex, includeSource: false), isFunctionShortName: true);
-                }
-            }
-            return validatedMetadata;
-        }
+            => _metadataValidator.ValidateMetadata(functions);
 
         internal FunctionMetadata ValidateBindings(IEnumerable<string> rawBindings, FunctionMetadata function)
-        {
-            HashSet<string> bindingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            // This method takes the RawBindings and adds them to the FunctionMetadata object. It's possible
-            // to call this twice, and we don't want to duplicate the bindings in that case.
-            function.Bindings.Clear();
-
-            foreach (string binding in rawBindings)
-            {
-                var sanitizedBinding = MetadataJsonHelper.CreateJObjectWithSanitizedPropertyValue(binding, ScriptConstants.SensitiveMetadataBindingPropertyNames, DateParseHandling.None);
-                var functionBinding = BindingMetadata.Create(sanitizedBinding);
-
-                Utility.ValidateBinding(functionBinding);
-
-                // Ensure no duplicate binding names exist
-                if (bindingNames.Contains(functionBinding.Name))
-                {
-                    throw new InvalidOperationException($"{nameof(WorkerFunctionDescriptorProvider)}: Multiple bindings with name '{functionBinding.Name}' discovered. Binding names must be unique.");
-                }
-
-                bindingNames.Add(functionBinding.Name);
-
-                // add binding to function.Bindings once validation is complete
-                function.Bindings.Add(functionBinding);
-            }
-
-            // ensure there is at least one binding after validation
-            if (function.Bindings == null || function.Bindings.Count == 0)
-            {
-                throw new FormatException("At least one binding must be declared.");
-            }
-
-            // ensure that there is a trigger binding
-            var triggerMetadata = function.InputBindings.FirstOrDefault(p => p.IsTrigger);
-            if (triggerMetadata == null)
-            {
-                throw new InvalidOperationException("No trigger binding specified. A function must have a trigger input binding.");
-            }
-
-            return function;
-        }
+            => WorkerFunctionMetadataValidator.ValidateBindings(rawBindings, function);
 
         private bool IsNullOrEmpty(IEnumerable<RawFunctionMetadata> functions)
         {

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -396,6 +396,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             catch (Exception ex)
             {
                 _workerInitTask.TrySetException(ex);
+                OnChannelFailure(ex);
                 _workerChannelLogger.LogError(ex, "Error processing inbound messages");
             }
             finally
@@ -1148,8 +1149,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 });
             }
 
-            // set it as task result because we cannot directly return from SendWorkerMetadataRequest
-            _functionsIndexingTask.SetResult(functions);
+            // Client channel failure can complete the pending request before a response arrives.
+            _functionsIndexingTask.TrySetResult(functions);
         }
 
         private async Task<object> GetBindingDataAsync(ParameterBinding binding, string invocationId)
@@ -1467,11 +1468,37 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         internal void HandleWorkerMetadataRequestError(Exception exc)
         {
             _workerChannelLogger.LogError(exc, "Requesting metadata from worker failed.");
+            OnMetadataRequestError(exc);
+        }
+
+        /// <summary>
+        /// Reports a metadata request failure through the worker-error event by default.
+        /// </summary>
+        /// <param name="exception">The metadata request failure.</param>
+        protected virtual void OnMetadataRequestError(Exception exception)
+        {
             if (_disposing || _disposed)
             {
                 return;
             }
-            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exc));
+            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exception));
+        }
+
+        /// <summary>
+        /// Allows derived channels to complete topology-specific operations when transport or shutdown fails.
+        /// </summary>
+        /// <param name="exception">The channel failure.</param>
+        protected virtual void OnChannelFailure(Exception exception)
+        {
+        }
+
+        /// <summary>
+        /// Fails the pending metadata request without replacing an existing result or failure.
+        /// </summary>
+        /// <param name="exception">The metadata request failure.</param>
+        protected void FailPendingMetadataRequest(Exception exception)
+        {
+            _functionsIndexingTask.TrySetException(exception);
         }
 
         private void HandleWorkerWarmupError(Exception exc)
@@ -1678,6 +1705,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         public void Shutdown(Exception workerException)
         {
             TryFailPendingReload(workerException);
+            if (workerException is not null)
+            {
+                OnChannelFailure(workerException);
+            }
 
             var shutdownException = workerException;
 

--- a/src/WebJobs.Script.Grpc/Metadata/WorkerFunctionMetadataValidator.cs
+++ b/src/WebJobs.Script.Grpc/Metadata/WorkerFunctionMetadataValidator.cs
@@ -1,0 +1,197 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc;
+
+/// <summary>
+/// Converts and validates raw metadata returned by a language worker.
+/// </summary>
+public sealed partial class WorkerFunctionMetadataValidator
+{
+    private readonly Lock _errorsLock = new();
+    private readonly ILogger _logger;
+    private readonly IWorkerRuntimeResolver _workerRuntimeResolver;
+    private ImmutableDictionary<string, ImmutableArray<string>> _functionErrors =
+        ImmutableDictionary<string, ImmutableArray<string>>.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkerFunctionMetadataValidator"/> class.
+    /// </summary>
+    /// <param name="logger">The logger used for metadata diagnostics.</param>
+    /// <param name="workerRuntimeResolver">The current worker runtime resolver.</param>
+    public WorkerFunctionMetadataValidator(ILogger logger, IWorkerRuntimeResolver workerRuntimeResolver)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _workerRuntimeResolver = workerRuntimeResolver ?? throw new ArgumentNullException(nameof(workerRuntimeResolver));
+    }
+
+    /// <summary>
+    /// Gets validation errors keyed by function name.
+    /// </summary>
+    public ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors
+    {
+        get
+        {
+            lock (_errorsLock)
+            {
+                return _functionErrors;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Validates raw worker metadata while retaining valid functions when another function is invalid.
+    /// </summary>
+    /// <param name="functions">The raw worker metadata.</param>
+    /// <returns>The valid function metadata.</returns>
+    public ImmutableArray<FunctionMetadata> ValidateMetadata(IEnumerable<RawFunctionMetadata> functions)
+    {
+        Dictionary<string, ICollection<string>> functionErrors = [];
+        if (functions is null || !functions.Any())
+        {
+            Log.NoMetadata(_logger);
+            SetFunctionErrors(ImmutableDictionary<string, ImmutableArray<string>>.Empty);
+            return [];
+        }
+
+        ImmutableArray<FunctionMetadata>.Builder validatedMetadata = ImmutableArray.CreateBuilder<FunctionMetadata>();
+        foreach (RawFunctionMetadata rawFunction in functions)
+        {
+            FunctionMetadata function = CloneFunctionMetadata(rawFunction?.Metadata);
+            try
+            {
+                if (rawFunction is null)
+                {
+                    throw new FormatException("The worker returned an empty function metadata entry.");
+                }
+
+                if (function is null)
+                {
+                    throw new FormatException("The worker returned function metadata without a function definition.");
+                }
+
+                Utility.ValidateName(function.Name);
+                function.Language = _workerRuntimeResolver.GetWorkerRuntime();
+
+                if (!string.IsNullOrEmpty(rawFunction.ConfigurationSource))
+                {
+                    JToken configurationSource = JToken.Parse(rawFunction.ConfigurationSource);
+                    string configurationSourceValue = configurationSource?.ToString();
+                    if (string.Equals(configurationSourceValue, "attributes", StringComparison.OrdinalIgnoreCase))
+                    {
+                        function.SetIsDirect(true);
+                    }
+                    else if (!string.Equals(configurationSourceValue, "config", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new FormatException(
+                            $"Illegal value '{configurationSourceValue}' for 'configurationSource' property in {function.Name}'.");
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(rawFunction.RetryOptions))
+                {
+                    function.Retry = JObject.Parse(rawFunction.RetryOptions).ToObject<RetryOptions>();
+                }
+
+                if (function.Retry is not null)
+                {
+                    Utility.ValidateRetryOptions(function.Retry);
+                }
+
+                validatedMetadata.Add(ValidateBindings(rawFunction.Bindings, function));
+            }
+            catch (Exception exception)
+            {
+                Utility.AddFunctionError(functionErrors, function?.Name, Utility.FlattenException(exception, includeSource: false),
+                    isFunctionShortName: true);
+            }
+        }
+
+        SetFunctionErrors(functionErrors.ToImmutableDictionary(pair => pair.Key, pair => pair.Value.ToImmutableArray()));
+        return validatedMetadata.ToImmutable();
+    }
+
+    internal static FunctionMetadata ValidateBindings(IEnumerable<string> rawBindings, FunctionMetadata function)
+    {
+        HashSet<string> bindingNames = new(StringComparer.OrdinalIgnoreCase);
+        function.Bindings.Clear();
+
+        foreach (string binding in rawBindings)
+        {
+            JObject sanitizedBinding = MetadataJsonHelper.CreateJObjectWithSanitizedPropertyValue(
+                binding, ScriptConstants.SensitiveMetadataBindingPropertyNames, DateParseHandling.None);
+            BindingMetadata functionBinding = BindingMetadata.Create(sanitizedBinding);
+
+            Utility.ValidateBinding(functionBinding);
+            if (!bindingNames.Add(functionBinding.Name))
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(WorkerFunctionDescriptorProvider)}: Multiple bindings with name '{functionBinding.Name}' discovered. Binding names must be unique.");
+            }
+
+            function.Bindings.Add(functionBinding);
+        }
+
+        if (function.Bindings is null || function.Bindings.Count == 0)
+        {
+            throw new FormatException("At least one binding must be declared.");
+        }
+
+        BindingMetadata triggerMetadata = function.InputBindings.FirstOrDefault(binding => binding.IsTrigger);
+        if (triggerMetadata is null)
+        {
+            throw new InvalidOperationException("No trigger binding specified. A function must have a trigger input binding.");
+        }
+
+        return function;
+    }
+
+    private static FunctionMetadata CloneFunctionMetadata(FunctionMetadata source)
+    {
+        if (source is null)
+        {
+            return null;
+        }
+
+        FunctionMetadata clone = new()
+        {
+            EntryPoint = source.EntryPoint,
+            FunctionDirectory = source.FunctionDirectory,
+            Language = source.Language,
+            Name = source.Name,
+            Retry = source.Retry,
+            ScriptFile = source.ScriptFile,
+        };
+        foreach (KeyValuePair<string, object> property in source.Properties)
+        {
+            clone.Properties.Add(property);
+        }
+
+        return clone;
+    }
+
+    private void SetFunctionErrors(ImmutableDictionary<string, ImmutableArray<string>> functionErrors)
+    {
+        lock (_errorsLock)
+        {
+            _functionErrors = functionErrors;
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Debug, "There is no metadata to be validated.")]
+        public static partial void NoMetadata(ILogger logger);
+    }
+}

--- a/src/WebJobs.Script/Host/FunctionMetadataResult.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
@@ -6,16 +6,30 @@ using Microsoft.Azure.WebJobs.Script.Description;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
-    internal class FunctionMetadataResult
+    /// <summary>
+    /// Contains worker-provided function metadata and its indexing disposition.
+    /// </summary>
+    public sealed class FunctionMetadataResult
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FunctionMetadataResult"/> class.
+        /// </summary>
+        /// <param name="useDefaultMetadataIndexing">Whether the host should use its default metadata indexing path.</param>
+        /// <param name="functions">The validated worker-provided functions.</param>
         public FunctionMetadataResult(bool useDefaultMetadataIndexing, ImmutableArray<FunctionMetadata> functions)
         {
-            this.UseDefaultMetadataIndexing = useDefaultMetadataIndexing;
-            this.Functions = functions;
+            UseDefaultMetadataIndexing = useDefaultMetadataIndexing;
+            Functions = functions;
         }
 
-        public bool UseDefaultMetadataIndexing { get; private set; }
+        /// <summary>
+        /// Gets a value indicating whether the host should use default metadata indexing.
+        /// </summary>
+        public bool UseDefaultMetadataIndexing { get; }
 
-        public ImmutableArray<FunctionMetadata> Functions { get; private set; }
+        /// <summary>
+        /// Gets the validated worker-provided functions.
+        /// </summary>
+        public ImmutableArray<FunctionMetadata> Functions { get; }
     }
 }

--- a/src/WebJobs.Script/Host/IWorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/IWorkerFunctionMetadataProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -11,14 +11,19 @@ namespace Microsoft.Azure.WebJobs.Script
     /// <summary>
     /// Defines an interface for fetching function metadata from Out-of-Proc language workers.
     /// </summary>
-    internal interface IWorkerFunctionMetadataProvider
+    public interface IWorkerFunctionMetadataProvider
     {
+        /// <summary>
+        /// Gets function-indexing errors keyed by function name.
+        /// </summary>
         ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors { get; }
 
         /// <summary>
         /// Attempts to get function metadata from Out-of-Proc language workers.
         /// </summary>
-        /// <returns>FunctionMetadataResult that either contains the function metadata or indicates that a fall back option for fetching metadata should be used</returns>
+        /// <param name="workerConfigs">The available worker configurations.</param>
+        /// <param name="forceRefresh">Whether to bypass the provider cache.</param>
+        /// <returns>A result containing worker metadata or requesting fallback to host indexing.</returns>
         Task<FunctionMetadataResult> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, bool forceRefresh = false);
     }
 }

--- a/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +38,7 @@ public sealed class RpcClientServiceCollectionExtensionsTests
         Assert.Same(services, result);
         AssertSingleton<IRpcClientFunctionInvocationDispatcher, RpcClientFunctionInvocationDispatcher>(services);
         AssertSingleton<IFunctionInvocationDispatcherFactory, RpcClientFunctionInvocationDispatcherFactory>(services);
+        AssertSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>(services);
     }
 
     private static void AssertSingleton<TService, TImplementation>(IServiceCollection services)

--- a/test/Functions.Rpc.Client.Tests/Metadata/RpcClientWorkerFunctionMetadataProviderTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Metadata/RpcClientWorkerFunctionMetadataProviderTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+public sealed class RpcClientWorkerFunctionMetadataProviderTests
+{
+    private const string HttpTriggerBinding = """{"type":"httpTrigger","name":"req","direction":"in"}""";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+    private readonly List<WorkerChannel> _channels = [];
+    private readonly Mock<IWorkerChannelRegistry> _registry = new();
+    private readonly Mock<IWorkerRuntimeResolver> _runtimeResolver = new();
+
+    public RpcClientWorkerFunctionMetadataProviderTests()
+    {
+        _registry.Setup(registry => registry.GetInitializedChannels())
+            .Returns(() => [.. _channels]);
+        _registry.Setup(registry => registry.WaitForFirstInitializedAsync(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken cancellationToken) => WaitForChannelAsync(cancellationToken));
+        _registry.Setup(registry => registry.UnlinkAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _runtimeResolver.Setup(resolver => resolver.GetWorkerRuntime(It.IsAny<string>()))
+            .Returns("dotnet-isolated");
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_ReturnsValidatedWorkerMetadata()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+
+        Task<FunctionMetadataResult> getMetadata = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync([CreateMetadata("HttpFunction", "function-id", HttpTriggerBinding)]);
+        FunctionMetadataResult result = await getMetadata.WaitAsync(TestTimeout);
+
+        FunctionMetadata function = Assert.Single(result.Functions);
+        Assert.False(result.UseDefaultMetadataIndexing);
+        Assert.Equal("HttpFunction", function.Name);
+        Assert.Equal("dotnet-isolated", function.Language);
+        Assert.Equal("httpTrigger", Assert.Single(function.Bindings).Type);
+        Assert.Empty(provider.FunctionErrors);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_WaitsForFirstInitializedChannel()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+
+        Task<FunctionMetadataResult> getMetadata = provider.GetFunctionMetadataAsync([]);
+        Assert.False(getMetadata.IsCompleted);
+
+        _channels.Add(worker.Channel);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync([CreateMetadata("HttpFunction", "function-id", HttpTriggerBinding)]);
+
+        Assert.Single((await getMetadata.WaitAsync(TestTimeout)).Functions);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_NoInitializedChannelTimesOut()
+    {
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider(TimeSpan.FromMilliseconds(50));
+
+        TimeoutException exception = await Assert.ThrowsAsync<TimeoutException>(
+            () => provider.GetFunctionMetadataAsync([]).WaitAsync(TestTimeout));
+
+        Assert.Contains("No client-backed worker channel initialized", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_DefaultIndexingRequestThrows()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+
+        Task<FunctionMetadataResult> firstRequest = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync(useDefaultMetadataIndexing: true);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => firstRequest.WaitAsync(TestTimeout));
+
+        Assert.Equal(
+            "Client-backed workers must provide function metadata and cannot request host metadata indexing.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_EmptyResultIsCached()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+
+        Task<FunctionMetadataResult> firstRequest = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync();
+        FunctionMetadataResult first = await firstRequest.WaitAsync(TestTimeout);
+        FunctionMetadataResult second = await provider.GetFunctionMetadataAsync([]);
+
+        Assert.False(first.UseDefaultMetadataIndexing);
+        Assert.Empty(first.Functions);
+        Assert.Same(first, second);
+        Assert.False(worker.Transport.Requests.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_ExposesValidationErrorsWhileRetainingWorkerResults()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+        RpcFunctionMetadata workerError = CreateMetadata("WorkerError", "worker-error", HttpTriggerBinding);
+        workerError.Status = new()
+        {
+            Status = StatusResult.Types.Status.Failure,
+            Exception = new() { Message = "worker indexing failed" },
+        };
+
+        Task<FunctionMetadataResult> getMetadata = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync(
+        [
+            CreateMetadata("Valid", "valid", HttpTriggerBinding),
+            CreateMetadata("Invalid", "invalid", """{"type":"blob","name":"output","direction":"out"}"""),
+            workerError,
+        ]);
+        FunctionMetadataResult result = await getMetadata.WaitAsync(TestTimeout);
+
+        Assert.Equal(["Valid", "WorkerError"],
+            result.Functions.Select(function => function.Name).OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Contains("Invalid", provider.FunctionErrors.Keys);
+        Assert.DoesNotContain("WorkerError", provider.FunctionErrors.Keys);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_ConcurrentCallersShareCacheFill()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+
+        Task<FunctionMetadataResult> firstRequest = provider.GetFunctionMetadataAsync([]);
+        Task<FunctionMetadataResult> secondRequest = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync([CreateMetadata("HttpFunction", "function-id", HttpTriggerBinding)]);
+        FunctionMetadataResult[] results = await Task.WhenAll(firstRequest, secondRequest).WaitAsync(TestTimeout);
+
+        Assert.Same(results[0], results[1]);
+        Assert.False(worker.Transport.Requests.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_ForceRefreshRebuildsProviderCacheFromChannelResult()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+
+        Task<FunctionMetadataResult> firstRequest = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync([CreateMetadata("First", "first", HttpTriggerBinding)]);
+        FunctionMetadataResult first = await firstRequest.WaitAsync(TestTimeout);
+
+        FunctionMetadataResult refreshed = await provider.GetFunctionMetadataAsync([], forceRefresh: true);
+
+        Assert.Equal("First", Assert.Single(first.Functions).Name);
+        Assert.Equal("First", Assert.Single(refreshed.Functions).Name);
+        Assert.NotSame(first, refreshed);
+        Assert.Same(refreshed, await provider.GetFunctionMetadataAsync([]));
+        Assert.False(worker.Transport.Requests.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_OverlappingProviderRefreshJoinsPendingChannelRequest()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider firstProvider = CreateProvider();
+        RpcClientWorkerFunctionMetadataProvider restartingProvider = CreateProvider();
+
+        Task<FunctionMetadataResult> firstRequest = firstProvider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        Task<FunctionMetadataResult> overlappingRefresh = restartingProvider.GetFunctionMetadataAsync([], forceRefresh: true);
+        Assert.False(worker.Transport.Requests.TryRead(out _));
+
+        await worker.SendFunctionMetadataResponseAsync([CreateMetadata("Shared", "shared", HttpTriggerBinding)]);
+        FunctionMetadataResult[] results = await Task.WhenAll(firstRequest, overlappingRefresh).WaitAsync(TestTimeout);
+
+        Assert.All(results, result => Assert.Equal("Shared", Assert.Single(result.Functions).Name));
+        Assert.NotSame(results[0].Functions[0], results[1].Functions[0]);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_ChannelFailureDoesNotPoisonProviderOrRegistry()
+    {
+        await using ClientWorkerChannelTestHarness failed = await ClientWorkerChannelTestHarness.CreateAsync("failed");
+        await using ClientWorkerChannelTestHarness replacement = await ClientWorkerChannelTestHarness.CreateAsync("replacement");
+        _channels.Add(failed.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider(TimeSpan.FromMilliseconds(50));
+
+        Task<FunctionMetadataResult> failedRequest = provider.GetFunctionMetadataAsync([]);
+        await failed.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        InvalidOperationException transportFailure = new("transport failed");
+        failed.Transport.CompleteResponses(transportFailure);
+        await Assert.ThrowsAnyAsync<Exception>(() => failedRequest.WaitAsync(TestTimeout));
+
+        _channels.Clear();
+        _channels.Add(replacement.Channel);
+        Task<FunctionMetadataResult> replacementRequest = provider.GetFunctionMetadataAsync([]);
+        await replacement.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await replacement.SendFunctionMetadataResponseAsync([CreateMetadata("Recovered", "recovered", HttpTriggerBinding)]);
+
+        Assert.Equal("Recovered", Assert.Single((await replacementRequest.WaitAsync(TestTimeout)).Functions).Name);
+        _registry.Verify(registry => registry.UnlinkAsync("failed", It.IsAny<CancellationToken>()), Times.Once);
+        _registry.Verify(registry => registry.DisposeAsync(), Times.Never);
+    }
+
+    private RpcClientWorkerFunctionMetadataProvider CreateProvider(TimeSpan? channelWaitTimeout = null)
+        => new(
+            _registry.Object,
+            NullLogger<RpcClientWorkerFunctionMetadataProvider>.Instance,
+            _runtimeResolver.Object,
+            channelWaitTimeout ?? TimeSpan.FromSeconds(10));
+
+    private async Task<WorkerChannel> WaitForChannelAsync(CancellationToken cancellationToken)
+    {
+        while (_channels.Count == 0)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
+        }
+
+        return _channels[0];
+    }
+
+    private static RpcFunctionMetadata CreateMetadata(
+        string name,
+        string functionId,
+        params string[] rawBindings)
+    {
+        RpcFunctionMetadata metadata = new()
+        {
+            FunctionId = functionId,
+            Language = "worker-language",
+            Name = name,
+            Status = new() { Status = StatusResult.Types.Status.Success },
+        };
+        metadata.RawBindings.Add(rawBindings);
+        return metadata;
+    }
+}

--- a/test/Functions.Rpc.Client.Tests/Metadata/RpcClientWorkerFunctionMetadataProviderTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Metadata/RpcClientWorkerFunctionMetadataProviderTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
@@ -82,6 +83,65 @@ public sealed class RpcClientWorkerFunctionMetadataProviderTests
             () => provider.GetFunctionMetadataAsync([]).WaitAsync(TestTimeout));
 
         Assert.Contains("No client-backed worker channel initialized", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_MetadataRequestCanOutlastChannelWaitTimeout()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider(TimeSpan.FromMilliseconds(50));
+
+        Task<FunctionMetadataResult> getMetadata = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+        await worker.SendFunctionMetadataResponseAsync([CreateMetadata("HttpFunction", "function-id", HttpTriggerBinding)]);
+
+        Assert.Single((await getMetadata.WaitAsync(TestTimeout)).Functions);
+        _registry.Verify(registry => registry.UnlinkAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Equal(0, worker.Transport.DisposeCount);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_ChannelShutdownUnlinksChannel()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider(TimeSpan.FromMilliseconds(50));
+
+        Task<FunctionMetadataResult> getMetadata = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        Task<List<RawFunctionMetadata>> channelMetadata = worker.Channel.GetFunctionMetadata();
+        TimeoutException channelFailure = new("Metadata request timed out.");
+
+        worker.Channel.Shutdown(channelFailure);
+
+        TimeoutException exception = await Assert.ThrowsAsync<TimeoutException>(() => getMetadata.WaitAsync(TestTimeout));
+        Assert.Same(channelFailure, exception);
+        Assert.True(channelMetadata.IsFaulted);
+        Assert.Same(exception, await Assert.ThrowsAsync<TimeoutException>(() => channelMetadata));
+        _registry.Verify(registry => registry.UnlinkAsync("worker", It.IsAny<CancellationToken>()), Times.Once);
+        _registry.Verify(registry => registry.DisposeAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_RequestErrorUnlinksWithoutPublishingWorkerError()
+    {
+        Mock<IScriptEventManager> eventManager = new();
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker", eventManager.Object);
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+        RpcFunctionMetadata metadata = CreateMetadata("HttpFunction", "function-id", HttpTriggerBinding);
+        metadata.RetryOptions = new() { RetryStrategy = (RpcRetryOptions.Types.RetryStrategy)(-1) };
+
+        Task<FunctionMetadataResult> getMetadata = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        await worker.SendFunctionMetadataResponseAsync([metadata]);
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => getMetadata.WaitAsync(TestTimeout));
+        Assert.Equal("Unknown RetryStrategy RpcDataType: -1.", exception.Message);
+        _registry.Verify(registry => registry.UnlinkAsync("worker", It.IsAny<CancellationToken>()), Times.Once);
+        eventManager.Verify(manager => manager.Publish(It.IsAny<WorkerErrorEvent>()), Times.Never);
     }
 
     [Fact]
@@ -221,7 +281,9 @@ public sealed class RpcClientWorkerFunctionMetadataProviderTests
         await failed.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
         InvalidOperationException transportFailure = new("transport failed");
         failed.Transport.CompleteResponses(transportFailure);
-        await Assert.ThrowsAnyAsync<Exception>(() => failedRequest.WaitAsync(TestTimeout));
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => failedRequest.WaitAsync(TestTimeout));
+        Assert.Same(transportFailure, exception);
 
         _channels.Clear();
         _channels.Add(replacement.Channel);
@@ -232,6 +294,27 @@ public sealed class RpcClientWorkerFunctionMetadataProviderTests
         Assert.Equal("Recovered", Assert.Single((await replacementRequest.WaitAsync(TestTimeout)).Functions).Name);
         _registry.Verify(registry => registry.UnlinkAsync("failed", It.IsAny<CancellationToken>()), Times.Once);
         _registry.Verify(registry => registry.DisposeAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_ChannelFailurePreservesUnlinkFailure()
+    {
+        await using ClientWorkerChannelTestHarness worker = await ClientWorkerChannelTestHarness.CreateAsync("worker");
+        _channels.Add(worker.Channel);
+        RpcClientWorkerFunctionMetadataProvider provider = CreateProvider();
+        InvalidOperationException transportFailure = new("transport failed");
+        InvalidOperationException unlinkFailure = new("unlink failed");
+        _registry.Setup(registry => registry.UnlinkAsync("worker", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(unlinkFailure);
+
+        Task<FunctionMetadataResult> getMetadata = provider.GetFunctionMetadataAsync([]);
+        await worker.ReadRequestAsync(StreamingMessage.ContentOneofCase.FunctionsMetadataRequest);
+        worker.Transport.CompleteResponses(transportFailure);
+
+        AggregateException exception = await Assert.ThrowsAsync<AggregateException>(() => getMetadata.WaitAsync(TestTimeout));
+        Assert.Collection(exception.InnerExceptions,
+            failure => Assert.Same(transportFailure, failure),
+            failure => Assert.Same(unlinkFailure, failure));
     }
 
     private RpcClientWorkerFunctionMetadataProvider CreateProvider(TimeSpan? channelWaitTimeout = null)

--- a/test/Functions.Rpc.Client.Tests/Registry/WorkerChannelRegistryTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Registry/WorkerChannelRegistryTests.cs
@@ -252,6 +252,24 @@ public sealed class WorkerChannelRegistryTests
     }
 
     [Fact]
+    public async Task Completion_DuringMetadataRequest_FailsProvider()
+    {
+        RegistryHarness harness = new();
+        ChannelControl channel = new("worker");
+        harness.Enqueue(channel);
+        await using WorkerChannelRegistry registry = harness.Registry;
+        await LinkAsync(registry, "worker");
+        RpcClientWorkerFunctionMetadataProvider provider = new(
+            registry, NullLogger<RpcClientWorkerFunctionMetadataProvider>.Instance, Mock.Of<IWorkerRuntimeResolver>());
+        Task<FunctionMetadataResult> metadata = provider.GetFunctionMetadataAsync([]);
+
+        channel.Complete();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => metadata.WaitAsync(TestTimeout));
+        Assert.False(registry.TryGetInitializedChannel("worker", out _));
+    }
+
+    [Fact]
     public async Task UnlinkAsync_RejectsRelinkUntilCleanupCompletes()
     {
         RegistryHarness harness = new();

--- a/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
+++ b/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
@@ -62,6 +63,16 @@ public class RpcClientAssemblyTests
             typeof(RpcClientFunctionInvocationDispatcher).GetInterfaces());
         Assert.Contains(typeof(IRpcClientFunctionInvocationDispatcher),
             typeof(RpcClientFunctionInvocationDispatcher).GetInterfaces());
+    }
+
+    [Fact]
+    public void ClientMetadataProviderUsesPublicSharedContracts()
+    {
+        Assert.True(typeof(IWorkerFunctionMetadataProvider).IsPublic);
+        Assert.True(typeof(FunctionMetadataResult).IsPublic);
+        Assert.True(typeof(WorkerFunctionMetadataValidator).IsPublic);
+        Assert.Contains(typeof(IWorkerFunctionMetadataProvider),
+            typeof(RpcClientWorkerFunctionMetadataProvider).GetInterfaces());
     }
 
     [Fact]

--- a/test/Functions.Rpc.Client.Tests/WorkerChannel/ClientWorkerChannelTestHarness.cs
+++ b/test/Functions.Rpc.Client.Tests/WorkerChannel/ClientWorkerChannelTestHarness.cs
@@ -35,10 +35,10 @@ internal sealed class ClientWorkerChannelTestHarness : IAsyncDisposable
 
     internal TestDuplexChannel<StreamingMessage> Transport { get; }
 
-    internal static async Task<ClientWorkerChannelTestHarness> CreateAsync(string workerId)
+    internal static async Task<ClientWorkerChannelTestHarness> CreateAsync(string workerId, IScriptEventManager eventManager = null)
     {
         TestDuplexChannel<StreamingMessage> transport = new();
-        RpcClientWorkerChannel channel = CreateFactory().Create(workerId, transport);
+        RpcClientWorkerChannel channel = CreateFactory(eventManager ?? new ScriptEventManager()).Create(workerId, transport);
         Task start = channel.StartAsync(CancellationToken.None);
 
         await transport.SendResponseAsync(new()
@@ -119,7 +119,7 @@ internal sealed class ClientWorkerChannelTestHarness : IAsyncDisposable
 
     public ValueTask DisposeAsync() => Channel.DisposeAsync();
 
-    private static RpcClientWorkerChannelFactory CreateFactory()
+    private static RpcClientWorkerChannelFactory CreateFactory(IScriptEventManager eventManager)
     {
         Mock<IScriptHostManager> hostManager = new();
         hostManager.As<IServiceProvider>()
@@ -133,7 +133,7 @@ internal sealed class ClientWorkerChannelTestHarness : IAsyncDisposable
             .Returns(true);
 
         return new(
-            new ScriptEventManager(),
+            eventManager,
             hostManager.Object,
             Mock.Of<IEnvironment>(),
             NullLoggerFactory.Instance,

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -989,6 +990,70 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             Assert.Equal(functions[0].Metadata.Properties.Count, 4);
             Assert.Equal(functions[0].Metadata.Properties["worker.functionId"], "fn1");
+        }
+
+        [Fact]
+        public async Task GetFunctionMetadata_MetadataRequestError_PublishesWorkerErrorWithoutCompletingMetadata()
+        {
+            await CreateDefaultWorkerChannel();
+            TaskCompletionSource<WorkerErrorEvent> workerError = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using IDisposable subscription = _eventManager.OfType<WorkerErrorEvent>().Subscribe(error => workerError.TrySetResult(error));
+            Task<List<RawFunctionMetadata>> metadata = _workerChannel.GetFunctionMetadata();
+            TimeoutException expectedException = new("Metadata request timed out.");
+
+            _workerChannel.HandleWorkerMetadataRequestError(expectedException);
+
+            WorkerErrorEvent errorEvent = await workerError.Task.WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.Same(expectedException, errorEvent.Exception);
+            Assert.Equal(_workerId, errorEvent.WorkerId);
+            Assert.False(metadata.IsCompleted);
+        }
+
+        [Fact]
+        public async Task GetFunctionMetadata_ShutdownWithWorkerException_LeavesMetadataPending()
+        {
+            await CreateDefaultWorkerChannel();
+            Task<List<RawFunctionMetadata>> metadata = _workerChannel.GetFunctionMetadata();
+            WorkerProcessExitException expectedException = new("Language Worker Process exited.") { Pid = 910 };
+
+            _workerChannel.Shutdown(expectedException);
+
+            Assert.False(metadata.IsCompleted);
+
+            _workerChannel.ProcessFunctionMetadataResponses(new()
+            {
+                Result = new() { Status = StatusResult.Types.Status.Success },
+                UseDefaultMetadataIndexing = false,
+            });
+
+            Assert.Empty(await metadata.WaitAsync(TimeSpan.FromSeconds(3)));
+        }
+
+        [Fact]
+        public async Task Dispose_WithPendingMetadata_LeavesMetadataPending()
+        {
+            await CreateDefaultWorkerChannel();
+            Task<List<RawFunctionMetadata>> metadata = _workerChannel.GetFunctionMetadata();
+
+            _workerChannel.Dispose();
+
+            Assert.False(metadata.IsCompleted);
+        }
+
+        [Fact]
+        public async Task GetFunctionMetadata_TransportFailure_LeavesMetadataPending()
+        {
+            await CreateDefaultWorkerChannel();
+            Task<List<RawFunctionMetadata>> metadata = _workerChannel.GetFunctionMetadata();
+
+            Assert.True(_serviceEndpoints.WorkerToHostWriter.TryComplete(new InvalidOperationException("Transport failed.")));
+            await TestHelpers.Await(
+                () => _logger.GetLogMessages().Any(message =>
+                    string.Equals(message.FormattedMessage, "Error processing inbound messages", StringComparison.Ordinal)),
+                timeout: 3000,
+                pollingInterval: 50);
+
+            Assert.False(metadata.IsCompleted);
         }
 
         [Fact]


### PR DESCRIPTION
Adds a Client-owned metadata provider that retrieves indexed functions from an initialized outbound worker channel and validates them through a shared topology-neutral validator.

The provider uses deterministic per-instance caching, rejects unsupported host metadata fallback, and leaves channel ownership with the Client registry. Client metadata remains reachable only through the test registration helper; compute composition is separate follow-up work.

### Issue describing the changes in this PR

resolves #11980

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

This is the top PR in a two-PR stack and targets the Client invocation dispatcher branch.