### PR TITLE
Add RPC client worker composition

### DIFF
--- a/src/Functions.Host/ClientWebHostWorkerManager.cs
+++ b/src/Functions.Host/ClientWebHostWorkerManager.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+
+namespace Azure.Functions.Host;
+
+/// <summary>
+/// Represents WebHost worker operations when worker lifecycle is controlled externally.
+/// </summary>
+internal sealed class ClientWebHostWorkerManager : IWebHostWorkerManager
+{
+    public Task SpecializeAsync() => Task.CompletedTask;
+
+    public Task WorkerWarmupAsync() => Task.CompletedTask;
+}

--- a/src/Functions.Host/ClientWorkerComposition.cs
+++ b/src/Functions.Host/ClientWorkerComposition.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using Azure.Functions.Rpc.Client;
 using Microsoft.Azure.WebJobs.Script.Composition;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Functions.Host/ClientWorkerComposition.cs
+++ b/src/Functions.Host/ClientWorkerComposition.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Azure.Functions.Rpc.Client;
 using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Azure.Functions.Host;
@@ -10,10 +12,6 @@ namespace Azure.Functions.Host;
 /// <summary>
 /// Defines the Client-backed worker composition for the separate Functions Host.
 /// </summary>
-/// <remarks>
-/// Client-backed registrations land in later milestones. The throwing methods make the intentionally incomplete
-/// boundary visible until those registrations are supplied.
-/// </remarks>
 internal sealed class ClientWorkerComposition : IWorkerComposition
 {
     private ClientWorkerComposition()
@@ -24,11 +22,18 @@ internal sealed class ClientWorkerComposition : IWorkerComposition
 
     public void ConfigureWebHostServices(IServiceCollection services, IMvcBuilder mvcBuilder)
     {
-        throw new NotImplementedException("Client WebHost worker composition is not implemented.");
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(mvcBuilder);
+
+        services.AddRpcClientServices();
+        services.AddSingleton<IWebHostWorkerManager, ClientWebHostWorkerManager>();
     }
 
     public void ConfigureScriptHostServices(IServiceCollection services, IServiceProvider rootServiceProvider)
     {
-        throw new NotImplementedException("Client ScriptHost worker composition is not implemented.");
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(rootServiceProvider);
+
+        services.AddRpcClientScriptHostServices(rootServiceProvider);
     }
 }

--- a/src/Functions.Host/Functions.Host.csproj
+++ b/src/Functions.Host/Functions.Host.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <!-- This interim reference makes the shared FunctionsHost entrypoint explicit. A later project split removes the
          transitive Rpc.Server implementation from the compute publish graph. -->
+    <ProjectReference Include="..\Functions.Rpc.Client\Functions.Rpc.Client.csproj" />
     <ProjectReference Include="..\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj" />
   </ItemGroup>
 

--- a/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
+++ b/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
@@ -2,50 +2,77 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Azure.Functions.Rpc.Client;
 
 /// <summary>
-/// Registers the Client transport and channel lifecycle for isolated tests.
+/// Registers the Client worker service graph.
 /// </summary>
-/// <remarks>Production composition must remain absent until compute composition explicitly consumes these registrations.</remarks>
-internal static class RpcClientServiceCollectionExtensions
+public static class RpcClientServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds the Client lifecycle as root-container singletons.
+    /// Adds the root-owned Client transport, channel factory, registry, and metadata services.
     /// </summary>
     /// <param name="services">The service collection to update.</param>
     /// <returns>The supplied service collection.</returns>
-    internal static IServiceCollection AddRpcClientServices(this IServiceCollection services)
+    public static IServiceCollection AddRpcClientServices(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ThrowIfRegistered<IRpcClientFactory>(services, nameof(AddRpcClientServices));
 
-        services.TryAddSingleton<IRpcClientFactory, RpcClientFactory>();
-        services.TryAddSingleton<IDuplexChannelFactory<StreamingMessage>, FunctionRpcDuplexChannelFactory>();
-        services.TryAddSingleton<IRpcClientWorkerChannelFactory, RpcClientWorkerChannelFactory>();
-        services.TryAddSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>();
+        services.AddDefaultHttpProxyService();
+        services.AddSingleton<IRpcClientFactory, RpcClientFactory>();
+        services.AddSingleton<IDuplexChannelFactory<StreamingMessage>, FunctionRpcDuplexChannelFactory>();
+        services.AddSingleton<IRpcClientWorkerChannelFactory, RpcClientWorkerChannelFactory>();
+        services.AddSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>();
+        services.AddSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>();
 
         return services;
     }
 
     /// <summary>
-    /// Adds Client services owned by one ScriptHost child container.
+    /// Adds Client services owned by one ScriptHost child container while borrowing the root-owned channel registry.
     /// </summary>
     /// <param name="services">The service collection to update.</param>
+    /// <param name="rootServiceProvider">The root provider that owns the Client channel registry.</param>
     /// <returns>The supplied service collection.</returns>
-    internal static IServiceCollection AddRpcClientScriptHostServices(this IServiceCollection services)
+    public static IServiceCollection AddRpcClientScriptHostServices(
+        this IServiceCollection services,
+        IServiceProvider rootServiceProvider)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(rootServiceProvider);
+        ThrowIfRegistered<IRpcClientFunctionInvocationDispatcher>(services, nameof(AddRpcClientScriptHostServices));
 
-        services.TryAddSingleton<IRpcClientFunctionInvocationDispatcher, RpcClientFunctionInvocationDispatcher>();
-        services.TryAddSingleton<IFunctionInvocationDispatcherFactory, RpcClientFunctionInvocationDispatcherFactory>();
-        services.TryAddSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>();
+        IWorkerChannelRegistry channelRegistry = rootServiceProvider.GetService<IWorkerChannelRegistry>()
+            ?? throw new InvalidOperationException(
+                $"The root service provider must be configured with {nameof(AddRpcClientServices)} before configuring ScriptHost services.");
+        IWorkerFunctionMetadataProvider metadataProvider = rootServiceProvider.GetService<IWorkerFunctionMetadataProvider>()
+            ?? throw new InvalidOperationException(
+                $"The root service provider must be configured with {nameof(AddRpcClientServices)} before configuring ScriptHost services.");
+
+        // ScriptHost children borrow these root-owned instances so child disposal cannot tear down linked channels or
+        // fork the metadata cache used by the root metadata manager.
+        services.AddSingleton(channelRegistry);
+        services.AddSingleton(metadataProvider);
+        services.AddSingleton<IRpcClientFunctionInvocationDispatcher, RpcClientFunctionInvocationDispatcher>();
+        services.AddSingleton<IFunctionInvocationDispatcherFactory, RpcClientFunctionInvocationDispatcherFactory>();
+        services.AddSingleton<IScriptHostWorkerManager, RpcClientScriptHostWorkerManager>();
+        services.AddRpcScriptHostCoreServices();
 
         return services;
+    }
+
+    private static void ThrowIfRegistered<TService>(IServiceCollection services, string registrationMethod)
+    {
+        if (services.Any(descriptor => descriptor.ServiceType == typeof(TService)))
+        {
+            throw new InvalidOperationException($"{registrationMethod} has already been called for this service collection.");
+        }
     }
 }

--- a/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
+++ b/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Linq;
+using Azure.Functions.Rpc.Client;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
-using Microsoft.Extensions.DependencyInjection;
 
-namespace Azure.Functions.Rpc.Client;
+namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Registers the Client worker service graph.

--- a/src/Functions.Rpc.Client/Metadata/RpcClientWorkerFunctionMetadataProvider.cs
+++ b/src/Functions.Rpc.Client/Metadata/RpcClientWorkerFunctionMetadataProvider.cs
@@ -21,8 +21,9 @@ namespace Azure.Functions.Rpc.Client;
 /// Retrieves and validates function metadata from a client-backed worker channel.
 /// </summary>
 /// <remarks>
-/// One provider belongs to a ScriptHost child container so its metadata cache is replaced on host restart. The provider
-/// borrows the root-owned registry and requests registry cleanup when a metadata operation makes a channel unusable.
+/// One provider belongs to the root container so the root metadata manager and ScriptHost children share one cache.
+/// The provider borrows the root-owned registry and requests registry cleanup when a metadata operation makes a channel
+/// unusable.
 /// </remarks>
 internal sealed partial class RpcClientWorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider
 {

--- a/src/Functions.Rpc.Client/WorkerManagement/RpcClientScriptHostWorkerManager.cs
+++ b/src/Functions.Rpc.Client/WorkerManagement/RpcClientScriptHostWorkerManager.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Workers;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Exposes ScriptHost worker status without owning externally managed worker processes.
+/// </summary>
+internal sealed class RpcClientScriptHostWorkerManager(
+    IRpcClientFunctionInvocationDispatcher dispatcher) : IScriptHostWorkerManager
+{
+    private readonly IRpcClientFunctionInvocationDispatcher _dispatcher =
+        dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+
+    public WorkerManagerState State => _dispatcher.State is FunctionInvocationDispatcherState.Default
+        ? WorkerManagerState.Default
+        : WorkerManagerState.Initialized;
+
+    public Task GetWorkerStatusesAsync()
+    {
+        return _dispatcher.State is FunctionInvocationDispatcherState.Initialized
+            ? _dispatcher.GetWorkerStatusesAsync()
+            : Task.CompletedTask;
+    }
+
+    public Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception)
+        => _dispatcher.RestartWorkerWithInvocationIdAsync(invocationId, exception);
+
+    public Task<IEnumerable<WorkerProcessInfo>> GetWorkerProcessInfoAsync(string workerRuntime)
+        => Task.FromResult<IEnumerable<WorkerProcessInfo>>([]);
+}

--- a/src/Functions.Rpc.Server/GrpcServiceCollectionsExtensions.cs
+++ b/src/Functions.Rpc.Server/GrpcServiceCollectionsExtensions.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
-using Microsoft.Azure.WebJobs.Script.Http;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -24,11 +23,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             services.TryAddSingleton<ServerDuplexChannelRegistry>();
             services.AddSingleton<IRpcWorkerChannelFactory, GrpcWorkerChannelFactory>();
             services.AddSingleton<FunctionRpc.FunctionRpcBase, FunctionRpcService>();
-
             services.AddSingleton<IRpcServer, AspNetCoreGrpcServer>();
 
-            services.AddHttpForwarder();
-            services.AddSingleton<IHttpProxyService, DefaultHttpProxyService>();
+            services.AddDefaultHttpProxyService();
 
             return services;
         }

--- a/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
@@ -71,7 +71,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                         // An host singleton is shared across tenant containers but only registered instances are not disposed
                         // by the DI, so we check if it is disposable or if it uses a factory which may return a different type.
 
-                        if (typeof(IDisposable).IsAssignableFrom(service.GetImplementationType()) || service.ImplementationFactory != null)
+                        Type implementationType = service.GetImplementationType();
+                        if (typeof(IDisposable).IsAssignableFrom(implementationType) ||
+                            typeof(IAsyncDisposable).IsAssignableFrom(implementationType) ||
+                            service.ImplementationFactory != null)
                         {
                             // If disposable, register an instance that we resolve immediately from the main container.
                             clonedCollection.CloneSingleton(service, serviceProvider.GetService(service.ServiceType));

--- a/src/WebJobs.Script/Http/HttpProxyServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script/Http/HttpProxyServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Http;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for registering the shared HTTP invocation proxy.
+/// </summary>
+public static class HttpProxyServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the default HTTP invocation proxy and its forwarding dependency.
+    /// </summary>
+    /// <param name="services">The service collection to update.</param>
+    /// <returns>The supplied service collection.</returns>
+    public static IServiceCollection AddDefaultHttpProxyService(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHttpForwarder();
+        services.AddSingleton<IHttpProxyService, DefaultHttpProxyService>();
+
+        return services;
+    }
+}

--- a/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
+++ b/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
@@ -2,44 +2,209 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
+using Azure.Functions.Rpc.Client;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Host;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Azure.Functions.Host.Tests;
 
 public class ClientWorkerCompositionTests
 {
+    private static readonly string[] ForbiddenWorkerImplementations =
+    [
+        "Microsoft.Azure.WebJobs.Script.Grpc.AspNetCoreGrpcServer",
+        "Microsoft.Azure.WebJobs.Script.Grpc.FunctionRpcService",
+        "Microsoft.Azure.WebJobs.Script.Grpc.GrpcWorkerChannelFactory",
+        "Microsoft.Azure.WebJobs.Script.Grpc.ServerDuplexChannelRegistry",
+        "Microsoft.Azure.WebJobs.Script.Rpc.RpcScriptHostWorkerManager",
+        "Microsoft.Azure.WebJobs.Script.Rpc.RpcWebHostWorkerManager",
+        "Microsoft.Azure.WebJobs.Script.WorkerFunctionMetadataProvider",
+        "Microsoft.Azure.WebJobs.Script.Workers.DefaultWorkerProcessFactory",
+        "Microsoft.Azure.WebJobs.Script.Workers.FunctionInvocationDispatcherFactory",
+        "Microsoft.Azure.WebJobs.Script.Workers.Http.DefaultHttpWorkerService",
+        "Microsoft.Azure.WebJobs.Script.Workers.Http.HttpWorkerProcessFactory",
+        "Microsoft.Azure.WebJobs.Script.Workers.HttpWorkerChannelFactory",
+        "Microsoft.Azure.WebJobs.Script.Workers.EmptyProcessRegistry",
+        "Microsoft.Azure.WebJobs.Script.Workers.JobObjectRegistry",
+        "Microsoft.Azure.WebJobs.Script.Workers.Rpc.JobHostRpcWorkerChannelManager",
+        "Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcFunctionInvocationDispatcherLoadBalancer",
+        "Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcInitializationService",
+        "Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcWorkerProcessFactory",
+        "Microsoft.Azure.WebJobs.Script.Workers.Rpc.WebHostRpcWorkerChannelManager",
+        "Microsoft.Azure.WebJobs.Script.Workers.WorkerConcurrencyManager",
+    ];
+
     [Fact]
-    public void ConfigureWebHostServices_ThrowsUntilClientWorkerCompositionIsImplemented()
+    public void ConfigureWebHostServices_RegistersExplicitRootClientGraph()
     {
         var services = new ServiceCollection();
-        IMvcBuilder mvcBuilder = services.AddMvc();
+        IMvcBuilder mvcBuilder = new ServiceCollection().AddMvc();
 
-        Assert.Throws<NotImplementedException>(
-            () => ClientWorkerComposition.Instance.ConfigureWebHostServices(services, mvcBuilder));
+        ClientWorkerComposition.Instance.ConfigureWebHostServices(services, mvcBuilder);
+
+        AssertSingleton(services, "Microsoft.Azure.WebJobs.Script.Http.IHttpProxyService",
+            "Microsoft.Azure.WebJobs.Script.Http.DefaultHttpProxyService");
+        AssertSingleton(services, "Azure.Functions.Rpc.Client.IRpcClientFactory",
+            "Azure.Functions.Rpc.Client.RpcClientFactory");
+        AssertSingleton(services, "Azure.Functions.Rpc.Client.IDuplexChannelFactory`1",
+            "Azure.Functions.Rpc.Client.FunctionRpcDuplexChannelFactory");
+        AssertSingleton(services, "Azure.Functions.Rpc.Client.IRpcClientWorkerChannelFactory",
+            "Azure.Functions.Rpc.Client.RpcClientWorkerChannelFactory");
+        AssertSingleton(services, "Azure.Functions.Rpc.Client.IWorkerChannelRegistry",
+            "Azure.Functions.Rpc.Client.WorkerChannelRegistry");
+        AssertSingleton(services, "Microsoft.Azure.WebJobs.Script.IWorkerFunctionMetadataProvider",
+            "Azure.Functions.Rpc.Client.RpcClientWorkerFunctionMetadataProvider");
+        AssertSingleton(services, "Microsoft.Azure.WebJobs.Script.WebHost.IWebHostWorkerManager",
+            "Azure.Functions.Host.ClientWebHostWorkerManager");
+        AssertNoServerWorkerServices(services);
     }
 
     [Fact]
-    public void ConfigureScriptHostServices_ThrowsUntilClientWorkerCompositionIsImplemented()
+    public async Task ConfigureScriptHostServices_ResolvesChildGraphWithRootRegistryIdentity()
+    {
+        IHost rootHost = CreateRootHost(out IServiceCollection rootServices);
+        try
+        {
+            Type registryType = GetServiceType(rootServices, "Azure.Functions.Rpc.Client.IWorkerChannelRegistry");
+            object rootRegistry = rootHost.Services.GetRequiredService(registryType);
+            IWorkerFunctionMetadataProvider rootMetadataProvider =
+                rootHost.Services.GetRequiredService<IWorkerFunctionMetadataProvider>();
+            IServiceCollection childServices = rootHost.Services.CreateChildContainer(rootServices);
+
+            ClientWorkerComposition.Instance.ConfigureScriptHostServices(childServices, rootHost.Services);
+            childServices.AddLogging();
+
+            ServiceDescriptor[] registryDescriptors = childServices.Where(service => service.ServiceType == registryType).ToArray();
+            Assert.Equal(2, registryDescriptors.Length);
+            Assert.All(registryDescriptors, descriptor => Assert.Same(rootRegistry, descriptor.ImplementationInstance));
+            ServiceDescriptor[] metadataDescriptors = childServices
+                .Where(service => service.ServiceType == typeof(IWorkerFunctionMetadataProvider))
+                .ToArray();
+            Assert.Equal(2, metadataDescriptors.Length);
+            Assert.Same(rootMetadataProvider, metadataDescriptors.Last().ImplementationInstance);
+            AssertNoServerWorkerServices(childServices);
+            Assert.DoesNotContain(childServices, descriptor =>
+                descriptor.ServiceType == typeof(IHostedService) &&
+                string.Equals(
+                    GetImplementationTypeName(descriptor),
+                    "Microsoft.Azure.WebJobs.Script.WebHost.WebJobsScriptHostService",
+                    StringComparison.Ordinal));
+
+            await using ServiceProvider childServiceProvider = childServices.BuildServiceProvider();
+            Assert.Same(rootRegistry, childServiceProvider.GetRequiredService(registryType));
+            Assert.All(childServiceProvider.GetServices(registryType), registry => Assert.Same(rootRegistry, registry));
+            Assert.Same(rootMetadataProvider, childServiceProvider.GetRequiredService<IWorkerFunctionMetadataProvider>());
+            Assert.All(childServiceProvider.GetServices<IWorkerFunctionMetadataProvider>(),
+                metadataProvider => Assert.Same(rootMetadataProvider, metadataProvider));
+            Assert.Equal("Azure.Functions.Rpc.Client.RpcClientFunctionInvocationDispatcher",
+                childServiceProvider.GetRequiredService<IRpcClientFunctionInvocationDispatcher>().GetType().FullName);
+            Assert.Equal("Azure.Functions.Rpc.Client.RpcClientFunctionInvocationDispatcherFactory",
+                childServiceProvider.GetRequiredService<IFunctionInvocationDispatcherFactory>().GetType().FullName);
+            Assert.Equal("Azure.Functions.Rpc.Client.RpcClientWorkerFunctionMetadataProvider",
+                childServiceProvider.GetRequiredService<IWorkerFunctionMetadataProvider>().GetType().FullName);
+            Assert.Equal("Microsoft.Azure.WebJobs.Script.Description.RpcWorkerFunctionDescriptorProviderFactory",
+                childServiceProvider.GetRequiredService<IWorkerFunctionDescriptorProviderFactory>().GetType().FullName);
+            Assert.Equal("Microsoft.Azure.WebJobs.Script.Rpc.RpcScriptHostLifecycleService",
+                childServiceProvider.GetRequiredService<IScriptHostLifecycleService>().GetType().FullName);
+            Assert.Equal("Azure.Functions.Rpc.Client.RpcClientScriptHostWorkerManager",
+                childServiceProvider.GetRequiredService<IScriptHostWorkerManager>().GetType().FullName);
+        }
+        finally
+        {
+            await ((IAsyncDisposable)rootHost).DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void ConfigureServices_ValidatesArguments()
     {
         var services = new ServiceCollection();
+        IMvcBuilder mvcBuilder = new ServiceCollection().AddMvc();
         using ServiceProvider rootServiceProvider = new ServiceCollection().BuildServiceProvider();
 
-        Assert.Throws<NotImplementedException>(
-            () => ClientWorkerComposition.Instance.ConfigureScriptHostServices(services, rootServiceProvider));
+        Assert.Throws<ArgumentNullException>(() =>
+            ClientWorkerComposition.Instance.ConfigureWebHostServices(null!, mvcBuilder));
+        Assert.Throws<ArgumentNullException>(() =>
+            ClientWorkerComposition.Instance.ConfigureWebHostServices(services, null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            ClientWorkerComposition.Instance.ConfigureScriptHostServices(null!, rootServiceProvider));
+        Assert.Throws<ArgumentNullException>(() =>
+            ClientWorkerComposition.Instance.ConfigureScriptHostServices(services, null!));
     }
 
     [Fact]
-    public void FunctionsHostReferencesSharedWebHostEntryPointWithoutDirectServer()
+    public void StaticCompositionSelection_PreventsCombiningServerAndClientGraphs()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+        services.AddWebJobsScriptHost(configuration);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddWebJobsScriptHost(configuration, ClientWorkerComposition.Instance));
+
+        Assert.True(exception.Message.Contains("already been selected", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RootProviderConstruction_ResolvesClientRegistryWithoutActivation()
+    {
+        IHost rootHost = CreateRootHost(out IServiceCollection services);
+        try
+        {
+            Type registryType = GetServiceType(services, "Azure.Functions.Rpc.Client.IWorkerChannelRegistry");
+
+            object registry = rootHost.Services.GetRequiredService(registryType);
+            IWorkerFunctionMetadataProvider metadataProvider =
+                rootHost.Services.GetRequiredService<IWorkerFunctionMetadataProvider>();
+            IFunctionMetadataManager metadataManager = rootHost.Services.GetRequiredService<IFunctionMetadataManager>();
+            IWebHostWorkerManager workerManager = rootHost.Services.GetRequiredService<IWebHostWorkerManager>();
+
+            Assert.Equal("Azure.Functions.Rpc.Client.WorkerChannelRegistry", registry.GetType().FullName);
+            Assert.Equal("Azure.Functions.Rpc.Client.RpcClientWorkerFunctionMetadataProvider",
+                metadataProvider.GetType().FullName);
+            Assert.IsType<FunctionMetadataManager>(metadataManager);
+            Assert.IsType<ClientWebHostWorkerManager>(workerManager);
+            await workerManager.SpecializeAsync();
+            await workerManager.WorkerWarmupAsync();
+            AssertNoServerWorkerServices(services);
+            Assert.DoesNotContain(services, descriptor =>
+                descriptor.ServiceType == typeof(IHostedService) &&
+                string.Equals(
+                    GetImplementationTypeName(descriptor),
+                    "Microsoft.Azure.WebJobs.Script.WebHost.WebJobsScriptHostService",
+                    StringComparison.Ordinal));
+        }
+        finally
+        {
+            await ((IAsyncDisposable)rootHost).DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void FunctionsHostReferencesClientAndSharedWebHostWithoutDirectServer()
     {
         string[] references = typeof(ClientWorkerComposition).Assembly.GetReferencedAssemblies()
             .Select(assembly => assembly.Name)
             .OfType<string>()
             .ToArray();
 
+        Assert.Contains("Azure.Functions.Rpc.Client", references);
         Assert.Contains("Microsoft.Azure.WebJobs.Script", references);
         Assert.Contains("Microsoft.Azure.WebJobs.Script.WebHost", references);
         Assert.DoesNotContain("Azure.Functions.Rpc.Server", references);
@@ -52,7 +217,7 @@ public class ClientWorkerCompositionTests
         XDocument project = XDocument.Load(Path.Combine(AppContext.BaseDirectory, "ProjectFiles", "Functions.Host.csproj"));
         XElement root = project.Root ?? throw new InvalidDataException("Functions.Host.csproj is missing its root Project element.");
         XElement frameworkReference = Assert.Single(project.Descendants("FrameworkReference"));
-        XElement projectReference = Assert.Single(project.Descendants("ProjectReference"));
+        XElement[] projectReferences = project.Descendants("ProjectReference").ToArray();
         XElement publishFilter = Assert.Single(project.Descendants("Target")
             .Where(target => string.Equals(
                 target.Attribute("Name")?.Value,
@@ -68,13 +233,85 @@ public class ClientWorkerCompositionTests
             "$(MSBuildThisFileDirectory)..\\WebJobs.Script.WebHost\\runtimeconfig.template.json",
             GetProperty(project, "UserRuntimeConfig"),
             StringComparison.Ordinal));
-        Assert.True(string.Equals(
-            "..\\WebJobs.Script.WebHost\\WebJobs.Script.WebHost.csproj",
-            projectReference.Attribute("Include")?.Value,
-            StringComparison.Ordinal));
+        Assert.Equal(
+            [
+                "..\\Functions.Rpc.Client\\Functions.Rpc.Client.csproj",
+                "..\\WebJobs.Script.WebHost\\WebJobs.Script.WebHost.csproj",
+            ],
+            projectReferences.Select(reference => reference.Attribute("Include")?.Value));
+        Assert.DoesNotContain(projectReferences, reference =>
+            reference.Attribute("Include")?.Value.Contains("Functions.Rpc.Server", StringComparison.Ordinal) is true);
+        Assert.DoesNotContain(projectReferences, reference =>
+            reference.Attribute("Include")?.Value.Contains("Functions.WorkerProxy", StringComparison.Ordinal) is true);
         Assert.True(string.Equals("Microsoft.AspNetCore.App", frameworkReference.Attribute("Include")?.Value, StringComparison.Ordinal));
         Assert.True(string.Equals("ComputeFilesToPublish", publishFilter.Attribute("AfterTargets")?.Value, StringComparison.Ordinal));
     }
+
+    private static IHost CreateRootHost(out IServiceCollection services)
+    {
+        IServiceCollection capturedServices = null!;
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+        IHost host = new HostBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.ConfigureServices(rootServices =>
+                {
+                    capturedServices = rootServices;
+                    rootServices.AddSingleton(configuration);
+                    rootServices.AddWebJobsScriptHost(configuration, ClientWorkerComposition.Instance);
+                    rootServices.Configure<ScriptApplicationHostOptions>(options =>
+                    {
+                        options.LogPath = Path.GetTempPath();
+                        options.ScriptPath = Directory.GetCurrentDirectory();
+                        options.SecretsPath = Path.GetTempPath();
+                    });
+                });
+                webBuilder.Configure(_ =>
+                {
+                });
+            })
+            .Build();
+
+        services = capturedServices;
+        return host;
+    }
+
+    private static Type GetServiceType(IServiceCollection services, string serviceTypeName)
+    {
+        return Assert.Single(services.Where(service =>
+            string.Equals(GetTypeName(service.ServiceType), serviceTypeName, StringComparison.Ordinal))).ServiceType;
+    }
+
+    private static void AssertSingleton(
+        IServiceCollection services,
+        string serviceTypeName,
+        string implementationTypeName)
+    {
+        ServiceDescriptor descriptor = Assert.Single(services.Where(service =>
+            string.Equals(GetTypeName(service.ServiceType), serviceTypeName, StringComparison.Ordinal)));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        Assert.True(string.Equals(
+            implementationTypeName,
+            GetImplementationTypeName(descriptor),
+            StringComparison.Ordinal));
+    }
+
+    private static void AssertNoServerWorkerServices(IEnumerable<ServiceDescriptor> services)
+    {
+        Assert.DoesNotContain(services, descriptor =>
+            ForbiddenWorkerImplementations.Contains(descriptor.ServiceType.FullName, StringComparer.Ordinal) ||
+            ForbiddenWorkerImplementations.Contains(descriptor.GetImplementationType()?.FullName, StringComparer.Ordinal));
+    }
+
+    private static string GetImplementationTypeName(ServiceDescriptor descriptor)
+    {
+        return descriptor.ImplementationType?.FullName
+            ?? descriptor.ImplementationInstance?.GetType().FullName
+            ?? string.Empty;
+    }
+
+    private static string GetTypeName(Type type)
+        => (type.IsGenericType ? type.GetGenericTypeDefinition() : type).FullName ?? string.Empty;
 
     private static string GetProperty(XDocument project, string name)
         => project.Descendants(name).Select(element => element.Value).First();

--- a/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
+++ b/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
@@ -54,7 +54,7 @@ public class ClientWorkerCompositionTests
     public void ConfigureWebHostServices_RegistersExplicitRootClientGraph()
     {
         var services = new ServiceCollection();
-        IMvcBuilder mvcBuilder = new ServiceCollection().AddMvc();
+        IMvcBuilder mvcBuilder = services.AddMvc();
 
         ClientWorkerComposition.Instance.ConfigureWebHostServices(services, mvcBuilder);
 
@@ -135,7 +135,7 @@ public class ClientWorkerCompositionTests
     public void ConfigureServices_ValidatesArguments()
     {
         var services = new ServiceCollection();
-        IMvcBuilder mvcBuilder = new ServiceCollection().AddMvc();
+        IMvcBuilder mvcBuilder = services.AddMvc();
         using ServiceProvider rootServiceProvider = new ServiceCollection().BuildServiceProvider();
 
         Assert.Throws<ArgumentNullException>(() =>

--- a/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
@@ -1,11 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Host;
+using Microsoft.Azure.WebJobs.Script.Http;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Azure.Functions.Rpc.Client.Tests;
@@ -18,27 +24,86 @@ public sealed class RpcClientServiceCollectionExtensionsTests
         ServiceCollection services = new();
 
         IServiceCollection result = services.AddRpcClientServices();
-        services.AddRpcClientServices();
 
         Assert.Same(services, result);
+        AssertSingleton(services, typeof(IHttpProxyService), "Microsoft.Azure.WebJobs.Script.Http.DefaultHttpProxyService");
         AssertSingleton<IRpcClientFactory, RpcClientFactory>(services);
         AssertSingleton<IDuplexChannelFactory<StreamingMessage>, FunctionRpcDuplexChannelFactory>(services);
         AssertSingleton<IRpcClientWorkerChannelFactory, RpcClientWorkerChannelFactory>(services);
         AssertSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>(services);
+        AssertSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>(services);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => services.AddRpcClientServices());
+        Assert.Contains(nameof(RpcClientServiceCollectionExtensions.AddRpcClientServices), exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void AddRpcClientScriptHostServices_RegistersDispatcherFactoryAsSingleton()
+    public void AddRpcClientScriptHostServices_RegistersRootRegistryBeforeChildServices()
     {
+        var rootRegistry = new Mock<IWorkerChannelRegistry>(MockBehavior.Strict);
+        var metadataProvider = new Mock<IWorkerFunctionMetadataProvider>(MockBehavior.Strict);
+        using ServiceProvider rootServiceProvider = new ServiceCollection()
+            .AddSingleton(rootRegistry.Object)
+            .AddSingleton(metadataProvider.Object)
+            .BuildServiceProvider();
         ServiceCollection services = new();
 
-        IServiceCollection result = services.AddRpcClientScriptHostServices();
-        services.AddRpcClientScriptHostServices();
+        IServiceCollection result = services.AddRpcClientScriptHostServices(rootServiceProvider);
 
         Assert.Same(services, result);
+        ServiceDescriptor registryDescriptor = Assert.Single(services.Where(service => service.ServiceType == typeof(IWorkerChannelRegistry)));
+        Assert.Same(rootRegistry.Object, registryDescriptor.ImplementationInstance);
+        ServiceDescriptor metadataDescriptor = Assert.Single(services.Where(service => service.ServiceType == typeof(IWorkerFunctionMetadataProvider)));
+        Assert.Same(metadataProvider.Object, metadataDescriptor.ImplementationInstance);
+        Assert.True(services.IndexOf(registryDescriptor) <
+            services.IndexOf(services.Single(service => service.ServiceType == typeof(IRpcClientFunctionInvocationDispatcher))));
         AssertSingleton<IRpcClientFunctionInvocationDispatcher, RpcClientFunctionInvocationDispatcher>(services);
         AssertSingleton<IFunctionInvocationDispatcherFactory, RpcClientFunctionInvocationDispatcherFactory>(services);
-        AssertSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>(services);
+        AssertSingleton<IScriptHostWorkerManager, RpcClientScriptHostWorkerManager>(services);
+        AssertSingleton(services, typeof(IWorkerFunctionDescriptorProviderFactory),
+            "Microsoft.Azure.WebJobs.Script.Description.RpcWorkerFunctionDescriptorProviderFactory");
+        AssertSingleton(services, typeof(IScriptHostLifecycleService),
+            "Microsoft.Azure.WebJobs.Script.Rpc.RpcScriptHostLifecycleService");
+    }
+
+    [Fact]
+    public async Task AddRpcClientScriptHostServices_ChildDisposalDoesNotDisposeRootRegistryOrChannels()
+    {
+        bool channelDisposed = false;
+        var rootRegistry = new Mock<IWorkerChannelRegistry>(MockBehavior.Strict);
+        var metadataProvider = new Mock<IWorkerFunctionMetadataProvider>(MockBehavior.Strict);
+        rootRegistry.Setup(registry => registry.DisposeAsync())
+            .Callback(() => channelDisposed = true)
+            .Returns(ValueTask.CompletedTask);
+        using ServiceProvider rootServiceProvider = new ServiceCollection()
+            .AddSingleton(rootRegistry.Object)
+            .AddSingleton(metadataProvider.Object)
+            .BuildServiceProvider();
+        ServiceCollection services = new();
+        services.AddRpcClientScriptHostServices(rootServiceProvider);
+
+        await using (ServiceProvider childServiceProvider = services.BuildServiceProvider())
+        {
+            Assert.Same(rootRegistry.Object, childServiceProvider.GetRequiredService<IWorkerChannelRegistry>());
+        }
+
+        rootRegistry.Verify(registry => registry.DisposeAsync(), Times.Never);
+        Assert.False(channelDisposed);
+    }
+
+    [Fact]
+    public void RegistrationMethods_ValidateArguments()
+    {
+        ServiceCollection services = new();
+        using ServiceProvider rootServiceProvider = new ServiceCollection().BuildServiceProvider();
+
+        Assert.Throws<ArgumentNullException>(() => RpcClientServiceCollectionExtensions.AddRpcClientServices(null));
+        Assert.Throws<ArgumentNullException>(() =>
+            RpcClientServiceCollectionExtensions.AddRpcClientScriptHostServices(null, rootServiceProvider));
+        Assert.Throws<ArgumentNullException>(() => services.AddRpcClientScriptHostServices(null));
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddRpcClientScriptHostServices(rootServiceProvider));
+        Assert.Contains(nameof(RpcClientServiceCollectionExtensions.AddRpcClientServices), exception.Message, StringComparison.Ordinal);
     }
 
     private static void AssertSingleton<TService, TImplementation>(IServiceCollection services)
@@ -46,5 +111,12 @@ public sealed class RpcClientServiceCollectionExtensionsTests
         ServiceDescriptor descriptor = Assert.Single(services.Where(service => service.ServiceType == typeof(TService)));
         Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
         Assert.Equal(typeof(TImplementation), descriptor.ImplementationType);
+    }
+
+    private static void AssertSingleton(IServiceCollection services, Type serviceType, string implementationTypeName)
+    {
+        ServiceDescriptor descriptor = Assert.Single(services.Where(service => service.ServiceType == serviceType));
+        Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+        Assert.Equal(implementationTypeName, descriptor.ImplementationType?.FullName);
     }
 }

--- a/test/WebJobs.Script.Tests/Extensions/ServiceProviderExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ServiceProviderExtensionsTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using AwesomeAssertions;
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -116,6 +118,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             object result = serviceProvider.CreateInstance(descriptor);
 
             result.Should().BeOfType<TestClass>();
+        }
+
+        [Fact]
+        public async Task CreateChildContainer_AsyncDisposableSingleton_IsBorrowedWithoutChildOwnership()
+        {
+            ServiceCollection rootServices = new();
+            rootServices.AddSingleton<ITestInterface, AsyncDisposableTestClass>();
+            await using ServiceProvider rootProvider = rootServices.BuildServiceProvider();
+            var rootInstance = (AsyncDisposableTestClass)rootProvider.GetRequiredService<ITestInterface>();
+            IServiceCollection childServices = rootProvider.CreateChildContainer(rootServices);
+            ServiceDescriptor descriptor = childServices.Single(service => service.ServiceType == typeof(ITestInterface));
+
+            descriptor.ImplementationInstance.Should().BeSameAs(rootInstance);
+
+            await using (ServiceProvider childProvider = childServices.BuildServiceProvider())
+            {
+                childProvider.GetRequiredService<ITestInterface>().Should().BeSameAs(rootInstance);
+            }
+
+            rootInstance.IsDisposed.Should().BeFalse();
+        }
+
+        private sealed class AsyncDisposableTestClass : ITestInterface, IAsyncDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public ValueTask DisposeAsync()
+            {
+                IsDisposed = true;
+                return ValueTask.CompletedTask;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds the static Client worker composition for the dedicated Functions Host without activating worker or ScriptHost lifecycle.

The root graph owns outbound RPC transport, linked worker channels, and the Client metadata provider. Each ScriptHost child borrows the same root registry and metadata provider and owns its Client dispatcher and shared process-neutral RPC lifecycle services. The composition explicitly omits inbound RPC server and local worker-process services.

### Issue describing the changes in this PR

resolves #11983

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

This PR extends the native Client worker stack above #12002. It constructs an inert service graph; deferred ScriptHost startup and worker-link lifecycle remain separate changes.

The metadata provider is root-owned rather than child-owned as originally proposed in #11983. The existing root `FunctionMetadataManager`/`FunctionMetadataProvider` needs `IWorkerFunctionMetadataProvider` before child-container creation. Forwarding the exact root instance gives both containers one shared metadata cache without transferring ownership.