### PR TITLE
adding StartupCoordinator

### DIFF
--- a/src/Functions.Host/ClientWorkerComposition.cs
+++ b/src/Functions.Host/ClientWorkerComposition.cs
@@ -24,7 +24,7 @@ internal sealed class ClientWorkerComposition : IWorkerComposition
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(mvcBuilder);
 
-        services.AddRpcClientServices();
+        services.AddRpcClientWebHostServices(static provider => provider.GetRequiredService<WebJobsScriptHostService>());
         services.AddSingleton<IWebHostWorkerManager, ClientWebHostWorkerManager>();
     }
 

--- a/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
+++ b/src/Functions.Rpc.Client/Extensions/RpcClientServiceCollectionExtensions.cs
@@ -7,6 +7,9 @@ using Azure.Functions.Rpc.Client;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -31,6 +34,34 @@ public static class RpcClientServiceCollectionExtensions
         services.AddSingleton<IRpcClientWorkerChannelFactory, RpcClientWorkerChannelFactory>();
         services.AddSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>();
         services.AddSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the Client worker graph, worker-backed Host metadata, and first-link ScriptHost activation.
+    /// </summary>
+    /// <param name="services">The root service collection to update.</param>
+    /// <param name="scriptHostFactory">Resolves the root-owned ScriptHost service whose activation is deferred.</param>
+    /// <returns>The supplied service collection.</returns>
+    /// <remarks>
+    /// The supplied ScriptHost service is borrowed, not registered as an automatically started <see cref="IHostedService"/>.
+    /// Use <see cref="AddRpcClientServices"/> when only transport and worker services are required, without ScriptHost activation.
+    /// </remarks>
+    public static IServiceCollection AddRpcClientWebHostServices(
+        this IServiceCollection services, Func<IServiceProvider, IHostedService> scriptHostFactory)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(scriptHostFactory);
+
+        services.AddRpcClientServices();
+        services.Replace(ServiceDescriptor.Singleton<IFunctionMetadataProvider, RpcClientFunctionMetadataProvider>());
+        services.AddSingleton(provider => new RpcClientScriptHostStartupCoordinator(
+            provider.GetRequiredService<IWorkerChannelRegistry>(),
+            scriptHostFactory(provider),
+            provider.GetRequiredService<IHostApplicationLifetime>(),
+            provider.GetRequiredService<ILogger<RpcClientScriptHostStartupCoordinator>>()));
+        services.AddSingleton<IHostedService>(provider => provider.GetRequiredService<RpcClientScriptHostStartupCoordinator>());
 
         return services;
     }

--- a/src/Functions.Rpc.Client/Hosting/RpcClientScriptHostStartupCoordinator.cs
+++ b/src/Functions.Rpc.Client/Hosting/RpcClientScriptHostStartupCoordinator.cs
@@ -1,0 +1,218 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Owns first-link activation and shutdown while borrowing the root ScriptHost service and worker registry.
+/// </summary>
+/// <param name="channelRegistry">The root-owned worker channel registry.</param>
+/// <param name="scriptHost">The root-owned ScriptHost service, supplied without an automatic hosted-service registration.</param>
+/// <param name="applicationLifetime">The root Host's application lifetime.</param>
+/// <param name="logger">The lifecycle logger.</param>
+internal sealed partial class RpcClientScriptHostStartupCoordinator(
+    IWorkerChannelRegistry channelRegistry,
+    IHostedService scriptHost,
+    IHostApplicationLifetime applicationLifetime,
+    ILogger<RpcClientScriptHostStartupCoordinator> logger) : IHostedService, IAsyncDisposable
+{
+    private readonly IWorkerChannelRegistry _channelRegistry = channelRegistry ?? throw new ArgumentNullException(nameof(channelRegistry));
+    private readonly IHostedService _scriptHost = scriptHost ?? throw new ArgumentNullException(nameof(scriptHost));
+    private readonly ILogger<RpcClientScriptHostStartupCoordinator> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly CancellationTokenSource _shutdown =
+        CancellationTokenSource.CreateLinkedTokenSource((applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime))).ApplicationStopping);
+
+    private readonly Lock _lifecycleLock = new();
+    private readonly Lock _disposeLock = new();
+    private Task? _activationTask;
+    private Task? _stopTask;
+    private Task? _disposeTask;
+
+    /// <summary>
+    /// Gets the first-link activation task, or <see langword="null"/> before this hosted service starts.
+    /// </summary>
+    /// <remarks>
+    /// Completion means the initial call to <see cref="IHostedService.StartAsync"/> has returned, not that ScriptHost is running.
+    /// The manager owns retries and exposes their outcome through <see cref="IScriptHostManager.State"/> and
+    /// <see cref="IScriptHostManager.LastError"/>. Later links do not replace this task.
+    /// </remarks>
+    public Task? ActivationTask
+    {
+        get
+        {
+            lock (_lifecycleLock)
+            {
+                return _activationTask;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_lifecycleLock)
+        {
+            if (_stopTask is not null)
+            {
+                throw new InvalidOperationException("Client ScriptHost startup has already stopped.");
+            }
+
+            _activationTask ??= ActivateScriptHostAsync();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Task stopTask;
+        lock (_lifecycleLock)
+        {
+            stopTask = _stopTask ??= StopCoreAsync();
+        }
+
+        // Cancel only this caller's wait; cleanup remains owned by the coordinator.
+        return stopTask.WaitAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync()
+    {
+        lock (_disposeLock)
+        {
+            return new(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private async Task ActivateScriptHostAsync()
+    {
+        // Even a preexisting link must not synchronously block root hosted-service startup.
+        await Task.Yield();
+        CancellationToken cancellationToken = _shutdown.Token;
+
+        try
+        {
+            await _channelRegistry.WaitForFirstInitializedAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            Log.LinkObserved(_logger);
+
+            Log.StartTriggered(_logger);
+            await _scriptHost.StartAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            Log.StartCallCompleted(_logger);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            Log.StartCanceled(_logger);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            Log.ActivationFailed(_logger, exception);
+            throw;
+        }
+    }
+
+    private async Task StopCoreAsync()
+    {
+        // Cancellation callbacks and child shutdown must run outside the lifecycle lock.
+        await Task.Yield();
+        Exception? cleanupException = null;
+        Exception? activationException = null;
+        try
+        {
+            await _shutdown.CancelAsync();
+        }
+        catch (Exception exception)
+        {
+            cleanupException = exception;
+        }
+
+        Task? activationTask = ActivationTask;
+        if (activationTask is not null)
+        {
+            try
+            {
+                await activationTask;
+            }
+            catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception)
+            {
+                // This failure is already logged and remains observable through ActivationTask.
+                activationException = exception;
+            }
+        }
+
+        try
+        {
+            await _scriptHost.StopAsync(CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            cleanupException = AggregateException.Combine(cleanupException, exception);
+        }
+
+        if (cleanupException is not null)
+        {
+            cleanupException = AggregateException.Combine(activationException, cleanupException);
+            Log.StopFailed(_logger, cleanupException);
+            ExceptionDispatchInfo.Capture(cleanupException).Throw();
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        Task stopTask = StopAsync(CancellationToken.None);
+        try
+        {
+            await stopTask;
+        }
+        catch (Exception) when (stopTask.IsFaulted || stopTask.IsCanceled)
+        {
+            // StopAsync retains and logs the failure. Rethrowing here would prevent the root container from disposing
+            // its remaining services, including the registry that owns the worker channels.
+        }
+        finally
+        {
+            _shutdown.Dispose();
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(0, LogLevel.Information, "The first initialized worker link was observed.")]
+        public static partial void LinkObserved(ILogger logger);
+
+        [LoggerMessage(1, LogLevel.Information, "Starting ScriptHost after the first initialized worker link.")]
+        public static partial void StartTriggered(ILogger logger);
+
+        [LoggerMessage(2, LogLevel.Information, "The initial ScriptHost startup call completed. ScriptHost manages any further startup retries.")]
+        public static partial void StartCallCompleted(ILogger logger);
+
+        [LoggerMessage(3, LogLevel.Error, "First-link ScriptHost activation failed. The worker registry remains available.")]
+        public static partial void ActivationFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(4, LogLevel.Information, "Deferred ScriptHost startup was canceled during shutdown.")]
+        public static partial void StartCanceled(ILogger logger);
+
+        [LoggerMessage(5, LogLevel.Error, "Client ScriptHost shutdown failed.")]
+        public static partial void StopFailed(ILogger logger, Exception exception);
+    }
+}

--- a/src/Functions.Rpc.Client/Metadata/RpcClientFunctionMetadataProvider.cs
+++ b/src/Functions.Rpc.Client/Metadata/RpcClientFunctionMetadataProvider.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Uses the root Client metadata cache without falling back to local application files.
+/// </summary>
+internal sealed class RpcClientFunctionMetadataProvider(IWorkerFunctionMetadataProvider workerMetadataProvider) : IFunctionMetadataProvider
+{
+    private readonly IWorkerFunctionMetadataProvider _workerMetadataProvider =
+        workerMetadataProvider ?? throw new ArgumentNullException(nameof(workerMetadataProvider));
+
+    public ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors => _workerMetadataProvider.FunctionErrors;
+
+    public async Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, bool forceRefresh = false)
+    {
+        FunctionMetadataResult result = await _workerMetadataProvider.GetFunctionMetadataAsync(workerConfigs, forceRefresh);
+        if (result.UseDefaultMetadataIndexing)
+        {
+            throw new InvalidOperationException("Client-backed Host requires worker-provided function metadata.");
+        }
+
+        return result.Functions;
+    }
+}

--- a/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
+++ b/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
@@ -26,6 +26,8 @@ namespace Azure.Functions.Host.Tests;
 
 public class ClientWorkerCompositionTests
 {
+    private const string StartupCoordinatorTypeName = "Azure.Functions.Rpc.Client.RpcClientScriptHostStartupCoordinator";
+
     private static readonly string[] ForbiddenWorkerImplementations =
     [
         "Microsoft.Azure.WebJobs.Script.Grpc.AspNetCoreGrpcServer",
@@ -72,6 +74,12 @@ public class ClientWorkerCompositionTests
             "Azure.Functions.Rpc.Client.RpcClientWorkerFunctionMetadataProvider");
         AssertSingleton(services, "Microsoft.Azure.WebJobs.Script.WebHost.IWebHostWorkerManager",
             "Azure.Functions.Host.ClientWebHostWorkerManager");
+        AssertSingleton(services, "Microsoft.Azure.WebJobs.Script.IFunctionMetadataProvider",
+            "Azure.Functions.Rpc.Client.RpcClientFunctionMetadataProvider");
+        ServiceDescriptor coordinator = Assert.Single(services.Where(service =>
+            string.Equals(service.ServiceType.FullName, StartupCoordinatorTypeName, StringComparison.Ordinal)));
+        Assert.Equal(ServiceLifetime.Singleton, coordinator.Lifetime);
+        Assert.NotNull(coordinator.ImplementationFactory);
         AssertNoServerWorkerServices(services);
     }
 
@@ -180,6 +188,15 @@ public class ClientWorkerCompositionTests
                 metadataProvider.GetType().FullName);
             Assert.IsType<FunctionMetadataManager>(metadataManager);
             Assert.IsType<ClientWebHostWorkerManager>(workerManager);
+            Assert.Equal("Azure.Functions.Rpc.Client.RpcClientFunctionMetadataProvider",
+                rootHost.Services.GetRequiredService<IFunctionMetadataProvider>().GetType().FullName);
+            IHostedService[] hostedServices = rootHost.Services.GetServices<IHostedService>().ToArray();
+            Assert.DoesNotContain(hostedServices, service => service is WebJobsScriptHostService);
+            Type coordinatorType = GetServiceType(services, StartupCoordinatorTypeName);
+            Assert.Same(rootHost.Services.GetRequiredService(coordinatorType),
+                Assert.Single(hostedServices.Where(service => string.Equals(service.GetType().FullName, StartupCoordinatorTypeName, StringComparison.Ordinal))));
+            Assert.Same(rootHost.Services.GetRequiredService<WebJobsScriptHostService>(),
+                rootHost.Services.GetRequiredService<IScriptHostManager>());
             await workerManager.SpecializeAsync();
             await workerManager.WorkerWarmupAsync();
             AssertNoServerWorkerServices(services);
@@ -194,6 +211,17 @@ public class ClientWorkerCompositionTests
         {
             await ((IAsyncDisposable)rootHost).DisposeAsync();
         }
+    }
+
+    [Fact]
+    public void StandardComposition_DoesNotRegisterClientStartupOrMetadata()
+    {
+        var services = new ServiceCollection();
+        services.AddWebJobsScriptHost(new ConfigurationBuilder().Build());
+
+        Assert.DoesNotContain(services, descriptor => string.Equals(descriptor.ServiceType.FullName, StartupCoordinatorTypeName, StringComparison.Ordinal));
+        Assert.DoesNotContain(services, descriptor =>
+            string.Equals(descriptor.ImplementationType?.FullName, "Azure.Functions.Rpc.Client.RpcClientFunctionMetadataProvider", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Extensions/RpcClientServiceCollectionExtensionsTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Script.Host;
 using Microsoft.Azure.WebJobs.Script.Http;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
 
@@ -32,9 +33,33 @@ public sealed class RpcClientServiceCollectionExtensionsTests
         AssertSingleton<IRpcClientWorkerChannelFactory, RpcClientWorkerChannelFactory>(services);
         AssertSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>(services);
         AssertSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>(services);
+        Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(RpcClientScriptHostStartupCoordinator));
+        Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(IHostedService));
 
         InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => services.AddRpcClientServices());
         Assert.Contains(nameof(RpcClientServiceCollectionExtensions.AddRpcClientServices), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddRpcClientWebHostServices_RegistersHostLifecycleWithoutDuplicatingMetadataProvider()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton(Mock.Of<IFunctionMetadataProvider>());
+        IHostedService scriptHost = Mock.Of<IHostedService>();
+
+        IServiceCollection result = services.AddRpcClientWebHostServices(_ => scriptHost);
+
+        Assert.Same(services, result);
+        AssertSingleton<IWorkerChannelRegistry, WorkerChannelRegistry>(services);
+        AssertSingleton<IWorkerFunctionMetadataProvider, RpcClientWorkerFunctionMetadataProvider>(services);
+        AssertSingleton<IFunctionMetadataProvider, RpcClientFunctionMetadataProvider>(services);
+        ServiceDescriptor coordinator = Assert.Single(services.Where(descriptor => descriptor.ServiceType == typeof(RpcClientScriptHostStartupCoordinator)));
+        Assert.Equal(ServiceLifetime.Singleton, coordinator.Lifetime);
+        Assert.NotNull(coordinator.ImplementationFactory);
+        ServiceDescriptor hostedService = Assert.Single(services.Where(descriptor => descriptor.ServiceType == typeof(IHostedService)));
+        Assert.Equal(ServiceLifetime.Singleton, hostedService.Lifetime);
+        Assert.NotNull(hostedService.ImplementationFactory);
+        Assert.Throws<InvalidOperationException>(() => services.AddRpcClientWebHostServices(_ => scriptHost));
     }
 
     [Fact]
@@ -98,6 +123,8 @@ public sealed class RpcClientServiceCollectionExtensionsTests
         using ServiceProvider rootServiceProvider = new ServiceCollection().BuildServiceProvider();
 
         Assert.Throws<ArgumentNullException>(() => RpcClientServiceCollectionExtensions.AddRpcClientServices(null));
+        Assert.Throws<ArgumentNullException>(() => RpcClientServiceCollectionExtensions.AddRpcClientWebHostServices(null, _ => Mock.Of<IHostedService>()));
+        Assert.Throws<ArgumentNullException>(() => services.AddRpcClientWebHostServices(null));
         Assert.Throws<ArgumentNullException>(() =>
             RpcClientServiceCollectionExtensions.AddRpcClientScriptHostServices(null, rootServiceProvider));
         Assert.Throws<ArgumentNullException>(() => services.AddRpcClientScriptHostServices(null));

--- a/test/Functions.Rpc.Client.Tests/Functions.Rpc.Client.Tests.csproj
+++ b/test/Functions.Rpc.Client.Tests/Functions.Rpc.Client.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Functions.Rpc.Client\Functions.Rpc.Client.csproj" />
+    <ProjectReference Include="..\..\src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Functions.Rpc.Client.Tests/Hosting/RpcClientScriptHostStartupCoordinatorTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Hosting/RpcClientScriptHostStartupCoordinatorTests.cs
@@ -1,0 +1,334 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+public class RpcClientScriptHostStartupCoordinatorTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(15);
+
+    [Fact]
+    public async Task StartAsync_NoLink_StartsRootWithoutStartingScriptHost()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+
+        await testHost.Host.StartAsync().WaitAsync(TestTimeout);
+        await testHost.WaitEntered.Task.WaitAsync(TestTimeout);
+
+        Assert.True(testHost.Host.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStarted.IsCancellationRequested);
+        Assert.False(testHost.Coordinator.ActivationTask.IsCompleted);
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
+        Assert.DoesNotContain(testHost.Host.Services.GetServices<IHostedService>(), service => ReferenceEquals(service, testHost.ScriptHost.Object));
+
+        await testHost.Host.StopAsync().WaitAsync(TestTimeout);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task StartAsync_FirstOrPreexistingLink_StartsExactlyOnce(bool preexistingLink)
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        if (preexistingLink)
+        {
+            testHost.CompleteLink();
+        }
+
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        testHost.CompleteLink();
+        Task activation = testHost.Coordinator.ActivationTask;
+        await activation.WaitAsync(TestTimeout);
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        testHost.CompleteLink();
+
+        Assert.Same(activation, testHost.Coordinator.ActivationTask);
+        Assert.True(activation.IsCompletedSuccessfully);
+        testHost.Registry.Verify(registry => registry.WaitForFirstInitializedAsync(It.IsAny<CancellationToken>()), Times.Once);
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_ConcurrentCallsShareOneActivation()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        testHost.ScriptHost.Setup(host => host.StartAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                entered.TrySetResult();
+                return release.Task;
+            });
+
+        await Task.WhenAll(Enumerable.Range(0, 20)
+            .Select(_ => Task.Run(() => testHost.Coordinator.StartAsync(CancellationToken.None))));
+        testHost.CompleteLink();
+        await entered.Task.WaitAsync(TestTimeout);
+        Assert.False(testHost.Coordinator.ActivationTask.IsCompleted);
+        release.SetResult();
+        await testHost.Coordinator.ActivationTask.WaitAsync(TestTimeout);
+
+        testHost.Registry.Verify(registry => registry.WaitForFirstInitializedAsync(It.IsAny<CancellationToken>()), Times.Once);
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_UnexpectedFailureIsObservableWithoutRepeatingTheCall()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        InvalidOperationException failure = new("Activation failed.");
+        testHost.ScriptHost.Setup(host => host.StartAsync(It.IsAny<CancellationToken>())).ThrowsAsync(failure);
+
+        testHost.CompleteLink();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        Task activation = testHost.Coordinator.ActivationTask;
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => activation.WaitAsync(TestTimeout)));
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        testHost.CompleteLink();
+
+        Assert.Same(activation, testHost.Coordinator.ActivationTask);
+        Assert.False(testHost.Host.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping.IsCancellationRequested);
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+        testHost.Registry.Verify(registry => registry.DisposeAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_ReturningDuringManagerRetry_DoesNotBecomeAnActivationFailure()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        InvalidOperationException failure = new("The manager is retrying startup.");
+        testHost.ScriptHostManager.SetupGet(manager => manager.State).Returns(ScriptHostState.Error);
+        testHost.ScriptHostManager.SetupGet(manager => manager.LastError).Returns(failure);
+        testHost.CompleteLink();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+
+        await testHost.Coordinator.ActivationTask.WaitAsync(TestTimeout);
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+
+        Assert.True(testHost.Coordinator.ActivationTask.IsCompletedSuccessfully);
+        Assert.Equal(ScriptHostState.Error, testHost.ScriptHostManager.Object.State);
+        Assert.Same(failure, testHost.ScriptHostManager.Object.LastError);
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_CanceledCallerDoesNotCancelExistingActivation()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        using CancellationTokenSource caller = new();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await testHost.WaitEntered.Task.WaitAsync(TestTimeout);
+        caller.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => testHost.Coordinator.StartAsync(caller.Token));
+        testHost.CompleteLink();
+        await testHost.Coordinator.ActivationTask.WaitAsync(TestTimeout);
+
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopAsync_BeforeStart_IsIdempotentAndPreventsActivation()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+
+        await Task.WhenAll(testHost.Coordinator.StopAsync(CancellationToken.None), testHost.Coordinator.StopAsync(CancellationToken.None))
+            .WaitAsync(TestTimeout);
+        testHost.CompleteLink();
+
+        Assert.Null(testHost.Coordinator.ActivationTask);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => testHost.Coordinator.StartAsync(CancellationToken.None));
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
+        testHost.ScriptHost.Verify(host => host.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopAsync_BeforeLink_CancelsOnlyTheCoordinatorWait()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await testHost.WaitEntered.Task.WaitAsync(TestTimeout);
+
+        await testHost.Coordinator.StopAsync(CancellationToken.None).WaitAsync(TestTimeout);
+        testHost.CompleteLink();
+
+        Assert.True(testHost.Coordinator.ActivationTask.IsCanceled);
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
+        testHost.Registry.Verify(registry => registry.DisposeAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task StopAsync_DuringActivation_CancelsAndStopsTheServiceOnce()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        testHost.ScriptHost.Setup(host => host.StartAsync(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken token) =>
+            {
+                entered.SetResult();
+                return Task.Delay(Timeout.InfiniteTimeSpan, token);
+            });
+        testHost.CompleteLink();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await entered.Task.WaitAsync(TestTimeout);
+
+        await Task.WhenAll(testHost.Coordinator.StopAsync(CancellationToken.None), testHost.Coordinator.StopAsync(CancellationToken.None))
+            .WaitAsync(TestTimeout);
+
+        Assert.True(testHost.Coordinator.ActivationTask.IsCanceled);
+        testHost.ScriptHost.Verify(host => host.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StopAsync_CanceledBeforeEntry_DoesNotBeginShutdown()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        using CancellationTokenSource caller = new();
+        testHost.CompleteLink();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await testHost.Coordinator.ActivationTask.WaitAsync(TestTimeout);
+        caller.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => testHost.Coordinator.StopAsync(caller.Token));
+
+        testHost.ScriptHost.Verify(host => host.StopAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StopAsync_CanceledCallerDoesNotAbandonOwnedCleanup()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        using CancellationTokenSource caller = new();
+        TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        testHost.ScriptHost.Setup(host => host.StartAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                entered.SetResult();
+                return release.Task;
+            });
+        testHost.CompleteLink();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await entered.Task.WaitAsync(TestTimeout);
+
+        Task canceledWait = testHost.Coordinator.StopAsync(caller.Token);
+        caller.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledWait.WaitAsync(TestTimeout));
+        Task stop = testHost.Coordinator.StopAsync(CancellationToken.None);
+        Assert.False(stop.IsCompleted);
+        release.SetResult();
+        await stop.WaitAsync(TestTimeout);
+
+        testHost.ScriptHost.Verify(host => host.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotentAndWaitsForShutdown()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        testHost.CompleteLink();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await testHost.Coordinator.ActivationTask.WaitAsync(TestTimeout);
+        TaskCompletionSource stopping = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource stopped = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        testHost.ScriptHost.Setup(host => host.StopAsync(It.IsAny<CancellationToken>())).Returns(() =>
+        {
+            stopping.SetResult();
+            return stopped.Task;
+        });
+
+        Task firstDispose = testHost.Coordinator.DisposeAsync().AsTask();
+        Task secondDispose = testHost.Coordinator.DisposeAsync().AsTask();
+        Assert.Same(firstDispose, secondDispose);
+        await stopping.Task.WaitAsync(TestTimeout);
+        Assert.False(firstDispose.IsCompleted);
+        stopped.SetResult();
+        await firstDispose.WaitAsync(TestTimeout);
+
+        testHost.ScriptHost.Verify(host => host.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        testHost.Registry.Verify(registry => registry.DisposeAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_StopFailure_DoesNotPreventRootRegistryDisposal()
+    {
+        await AssertRootDisposalAfterStopFailureAsync(new InvalidOperationException("ScriptHost stop failed."), stopBeforeDispose: false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DisposeAsync_StopFailure_RemainsObservableAfterDisposal(bool canceled)
+    {
+        Exception failure = canceled ? new OperationCanceledException("ScriptHost stop timed out.") : new InvalidOperationException("ScriptHost stop failed.");
+
+        await AssertRootDisposalAfterStopFailureAsync(failure, stopBeforeDispose: true);
+    }
+
+    [Fact]
+    public async Task StopAsync_PreservesActivationAndShutdownFailures()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        InvalidOperationException activationFailure = new("Activation failed.");
+        InvalidOperationException shutdownFailure = new("Shutdown failed.");
+        testHost.ScriptHost.Setup(host => host.StartAsync(It.IsAny<CancellationToken>())).ThrowsAsync(activationFailure);
+        testHost.ScriptHost.Setup(host => host.StopAsync(It.IsAny<CancellationToken>())).ThrowsAsync(shutdownFailure);
+        testHost.CompleteLink();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => testHost.Coordinator.ActivationTask.WaitAsync(TestTimeout));
+
+        AggregateException failure = await Assert.ThrowsAsync<AggregateException>(() => testHost.Coordinator.StopAsync(CancellationToken.None));
+
+        Assert.Equal([activationFailure, shutdownFailure], failure.InnerExceptions);
+    }
+
+    [Fact]
+    public async Task ApplicationStopping_CancelsDeferredActivationBeforeStopAsync()
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        await testHost.Coordinator.StartAsync(CancellationToken.None);
+        await testHost.WaitEntered.Task.WaitAsync(TestTimeout);
+
+        testHost.Host.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => testHost.Coordinator.ActivationTask.WaitAsync(TestTimeout));
+        testHost.CompleteLink();
+
+        testHost.ScriptHost.Verify(host => host.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static async Task AssertRootDisposalAfterStopFailureAsync(Exception failure, bool stopBeforeDispose)
+    {
+        await using RpcClientStartupTestHost testHost = new();
+        testHost.ScriptHost.Setup(host => host.StopAsync(It.IsAny<CancellationToken>())).ThrowsAsync(failure);
+        RpcClientScriptHostStartupCoordinator coordinator = testHost.Coordinator;
+        testHost.CompleteLink();
+        await coordinator.StartAsync(CancellationToken.None);
+        await coordinator.ActivationTask.WaitAsync(TestTimeout);
+
+        if (stopBeforeDispose)
+        {
+            Assert.Same(failure, await Assert.ThrowsAnyAsync<Exception>(() => coordinator.StopAsync(CancellationToken.None).WaitAsync(TestTimeout)));
+        }
+
+        await testHost.DisposeAsync();
+
+        testHost.Registry.Verify(registry => registry.DisposeAsync(), Times.Once);
+        testHost.ScriptHost.Verify(host => host.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Same(failure, await Assert.ThrowsAnyAsync<Exception>(() => coordinator.StopAsync(CancellationToken.None)));
+        Assert.Contains(testHost.Logger.Invocations, invocation =>
+            string.Equals(invocation.Method.Name, nameof(ILogger.Log), StringComparison.Ordinal) &&
+            invocation.Arguments[0] is LogLevel.Error && invocation.Arguments[1] is EventId { Id: 5 } &&
+            ReferenceEquals(invocation.Arguments[3], failure));
+    }
+}

--- a/test/Functions.Rpc.Client.Tests/Hosting/RpcClientScriptHostStartupIntegrationTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Hosting/RpcClientScriptHostStartupIntegrationTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+public class RpcClientScriptHostStartupIntegrationTests
+{
+    private const string HostConfiguration = """{"version":"2.0","isDefaultHostConfig":true}""";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task FirstLink_IndexesWorkerMetadataWithExistingHostConfiguration_AndLaterLinksDoNotRestart()
+    {
+        await using TestWorker firstWorker = await TestWorker.StartAsync("first");
+        await using TestWorker laterWorker = await TestWorker.StartAsync("later");
+        using CancellationTokenSource timeout = new(TestTimeout);
+
+        await using (ClientTestHost testHost = new())
+        {
+            await testHost.Host.StartAsync(timeout.Token);
+            IWorkerChannelRegistry registry = testHost.Host.Services.GetRequiredService<IWorkerChannelRegistry>();
+            RpcClientScriptHostStartupCoordinator coordinator = testHost.Host.Services.GetRequiredService<RpcClientScriptHostStartupCoordinator>();
+            IScriptHostManager manager = testHost.Host.Services.GetRequiredService<IScriptHostManager>();
+
+            Assert.Null(manager.Services);
+            Assert.Equal(ScriptHostState.Default, manager.State);
+            Assert.False(coordinator.ActivationTask!.IsCompleted);
+            Assert.Equal("host.json", Path.GetFileName(Assert.Single(Directory.GetFiles(testHost.ScriptPath))));
+            Assert.DoesNotContain(testHost.Host.Services.GetServices<IHostedService>(), service => service is WebJobsScriptHostService);
+
+            WorkerChannel firstChannel = await registry.LinkAsync("first", firstWorker.Endpoint, timeout.Token);
+            await coordinator.ActivationTask!.WaitAsync(timeout.Token);
+            await WaitForHostStateAsync(manager, ScriptHostState.Running, timeout.Token);
+            await firstWorker.Service.FunctionLoaded.Task.WaitAsync(timeout.Token);
+
+            Assert.Equal(ScriptHostState.Running, manager.State);
+            IServiceProvider scriptServices = Assert.IsAssignableFrom<IServiceProvider>(manager.Services);
+            ScriptHost scriptHost = scriptServices.GetRequiredService<ScriptHost>();
+            FunctionDescriptor function = Assert.Single(scriptHost.Functions);
+            Assert.Equal("Http", function.Name);
+            Assert.Equal(AuthorizationLevel.Anonymous, function.HttpTriggerAttribute.AuthLevel);
+            var logCalls = testHost.Logger.Invocations
+                .Where(invocation => string.Equals(invocation.Method.Name, nameof(ILogger.Log), StringComparison.Ordinal))
+                .ToArray();
+            Assert.NotEmpty(logCalls);
+            Assert.DoesNotContain(logCalls, invocation => invocation.Arguments[1] is EventId { Id: 340 });
+            Assert.True(scriptServices.GetRequiredService<IOptions<ScriptJobHostOptions>>().Value.IsDefaultHostConfig);
+            Assert.Same(registry, scriptServices.GetRequiredService<IWorkerChannelRegistry>());
+            Assert.Same(testHost.Host.Services.GetRequiredService<IWorkerFunctionMetadataProvider>(),
+                scriptServices.GetRequiredService<IWorkerFunctionMetadataProvider>());
+            Assert.Equal(1, firstWorker.Service.MetadataRequests);
+            Assert.Equal(HostConfiguration, File.ReadAllText(Path.Combine(testHost.ScriptPath, "host.json")));
+            Assert.Equal("Files", testHost.Configuration[EnvironmentSettingNames.AzureWebJobsSecretStorageType]);
+            Assert.True(testHost.Host.Services.GetRequiredService<ISecretManagerProvider>().SecretsEnabled);
+
+            await registry.LinkAsync("later", laterWorker.Endpoint, timeout.Token);
+
+            Assert.Same(scriptServices, manager.Services);
+            Assert.Same(scriptHost, scriptServices.GetRequiredService<ScriptHost>());
+            Assert.Equal(2, registry.GetInitializedChannels().Count);
+            Assert.Equal(1, firstWorker.Service.MetadataRequests);
+            Assert.Equal(0, laterWorker.Service.MetadataRequests);
+
+            await coordinator.StopAsync(timeout.Token);
+
+            Assert.Equal(ScriptHostState.Stopped, manager.State);
+            Assert.Null(manager.Services);
+            Assert.True(registry.TryGetInitializedChannel("first", out WorkerChannel retainedChannel));
+            Assert.Same(firstChannel, retainedChannel);
+        }
+
+        await firstWorker.Service.Disconnected.Task.WaitAsync(timeout.Token);
+        await laterWorker.Service.Disconnected.Task.WaitAsync(timeout.Token);
+    }
+
+    [Theory]
+    [InlineData("host.json", "{invalid json", ScriptHostState.Error)]
+    [InlineData("app_offline.htm", "offline", ScriptHostState.Offline)]
+    public async Task FirstLink_LeavesConfigurationErrorsAndOfflineHandlingWithTheManager(
+        string fileName, string content, ScriptHostState expectedState)
+    {
+        await using TestWorker worker = await TestWorker.StartAsync("worker");
+        await using ClientTestHost testHost = new();
+        using CancellationTokenSource timeout = new(TestTimeout);
+        File.WriteAllText(Path.Combine(testHost.ScriptPath, fileName), content);
+        await testHost.Host.StartAsync(timeout.Token);
+        IWorkerChannelRegistry registry = testHost.Host.Services.GetRequiredService<IWorkerChannelRegistry>();
+        RpcClientScriptHostStartupCoordinator coordinator = testHost.Host.Services.GetRequiredService<RpcClientScriptHostStartupCoordinator>();
+        IScriptHostManager manager = testHost.Host.Services.GetRequiredService<IScriptHostManager>();
+
+        WorkerChannel channel = await registry.LinkAsync("worker", worker.Endpoint, timeout.Token);
+        await coordinator.ActivationTask!.WaitAsync(timeout.Token);
+        await WaitForHostStateAsync(manager, expectedState, timeout.Token);
+        Task activation = coordinator.ActivationTask!;
+        await coordinator.StartAsync(timeout.Token);
+
+        Assert.Same(activation, coordinator.ActivationTask);
+        Assert.True(activation.IsCompletedSuccessfully);
+        Assert.Equal(expectedState, manager.State);
+        if (expectedState is ScriptHostState.Error)
+        {
+            Assert.IsType<FormatException>(manager.LastError);
+        }
+        else
+        {
+            Assert.Null(manager.LastError);
+        }
+
+        Assert.False(testHost.Host.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping.IsCancellationRequested);
+        Assert.True(registry.TryGetInitializedChannel("worker", out WorkerChannel retainedChannel));
+        Assert.Same(channel, retainedChannel);
+        Assert.Equal(0, worker.Service.MetadataRequests);
+    }
+
+    [Fact]
+    public async Task FirstLink_TransientHostBuildFailure_IsRetriedByTheExistingManager()
+    {
+        await using TestWorker worker = await TestWorker.StartAsync("worker");
+        InvalidOperationException failure = new("Transient host build failure.");
+        var configureBuilder = new Mock<IConfigureBuilder<IServiceCollection>>();
+        configureBuilder.SetupSequence(builder => builder.Configure(It.IsAny<IServiceCollection>()))
+            .Throws(failure)
+            .Pass();
+        await using ClientTestHost testHost = new(services => services.AddSingleton(configureBuilder.Object));
+        using CancellationTokenSource timeout = new(TestTimeout);
+        await testHost.Host.StartAsync(timeout.Token);
+        IWorkerChannelRegistry registry = testHost.Host.Services.GetRequiredService<IWorkerChannelRegistry>();
+        RpcClientScriptHostStartupCoordinator coordinator = testHost.Host.Services.GetRequiredService<RpcClientScriptHostStartupCoordinator>();
+        IScriptHostManager manager = testHost.Host.Services.GetRequiredService<IScriptHostManager>();
+
+        await registry.LinkAsync("worker", worker.Endpoint, timeout.Token);
+        await coordinator.ActivationTask!.WaitAsync(timeout.Token);
+        await WaitForHostStateAsync(manager, ScriptHostState.Running, timeout.Token);
+        Task activation = coordinator.ActivationTask!;
+        await coordinator.StartAsync(timeout.Token);
+
+        Assert.Same(activation, coordinator.ActivationTask);
+        Assert.Null(manager.LastError);
+        Assert.Single(manager.Services!.GetRequiredService<ScriptHost>().Functions);
+        configureBuilder.Verify(builder => builder.Configure(It.IsAny<IServiceCollection>()), Times.Exactly(2));
+        Assert.True(registry.TryGetInitializedChannel("worker", out _));
+    }
+
+    private static async Task WaitForHostStateAsync(IScriptHostManager manager, ScriptHostState state, CancellationToken cancellationToken)
+    {
+        while (manager.State != state)
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+    }
+
+    private sealed class ClientTestHost : IAsyncDisposable
+    {
+        private readonly string _directory = Path.Combine(Path.GetTempPath(), $"ClientHost-{Guid.NewGuid():N}");
+
+        public ClientTestHost(Action<IServiceCollection>? configureServices = null)
+        {
+            ScriptPath = Path.Combine(_directory, "app");
+            Directory.CreateDirectory(ScriptPath);
+            File.WriteAllText(Path.Combine(ScriptPath, "host.json"), HostConfiguration);
+            Configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [EnvironmentSettingNames.FunctionWorkerRuntime] = "dotnet-isolated",
+                [EnvironmentSettingNames.AzureWebJobsSecretStorageType] = "Files",
+                ["AzureFunctionsWebHost:ScriptPath"] = ScriptPath,
+                ["AzureFunctionsWebHost:LogPath"] = Path.Combine(_directory, "logs"),
+                ["AzureFunctionsWebHost:SecretsPath"] = Path.Combine(_directory, "secrets"),
+                ["AzureFunctionsWebHost:IsSelfHost"] = "true",
+            }).Build();
+            var environment = new Mock<IEnvironment>();
+            environment.Setup(value => value.GetEnvironmentVariable(It.IsAny<string>())).Returns((string name) => Configuration[name]!);
+            Logger.Setup(logger => logger.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+            var loggerProvider = new Mock<ILoggerProvider>();
+            loggerProvider.Setup(provider => provider.CreateLogger(It.IsAny<string>())).Returns(Logger.Object);
+            var composition = new Mock<IWorkerComposition>();
+            composition.Setup(value => value.ConfigureWebHostServices(It.IsAny<IServiceCollection>(), It.IsAny<IMvcBuilder>()))
+                .Callback<IServiceCollection, IMvcBuilder>((services, _) =>
+                {
+                    services.AddRpcClientWebHostServices(static provider => provider.GetRequiredService<WebJobsScriptHostService>());
+                    services.AddSingleton(Mock.Of<IWebHostWorkerManager>());
+                });
+            composition.Setup(value => value.ConfigureScriptHostServices(It.IsAny<IServiceCollection>(), It.IsAny<IServiceProvider>()))
+                .Callback<IServiceCollection, IServiceProvider>((services, provider) => services.AddRpcClientScriptHostServices(provider));
+
+            Host = new HostBuilder().ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseUrls("http://127.0.0.1:0");
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddSingleton(Configuration);
+                    services.AddSingleton(environment.Object);
+                    services.AddWebJobsScriptHost(Configuration, composition.Object);
+                    services.AddSingleton<IConfigureBuilder<ILoggingBuilder>>(new TestLogging(loggerProvider.Object));
+                    configureServices?.Invoke(services);
+                });
+                webBuilder.Configure(_ => { });
+            }).Build();
+        }
+
+        public string ScriptPath { get; }
+
+        public IConfiguration Configuration { get; }
+
+        public IHost Host { get; }
+
+        public Mock<ILogger> Logger { get; } = new();
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await Host.StopAsync().WaitAsync(TestTimeout);
+            }
+            finally
+            {
+                await ((IAsyncDisposable)Host).DisposeAsync();
+                Directory.Delete(_directory, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestLogging(ILoggerProvider loggerProvider) : IConfigureBuilder<ILoggingBuilder>
+    {
+        public void Configure(ILoggingBuilder builder) => builder.AddProvider(loggerProvider);
+    }
+
+    private sealed class TestWorker(WebApplication application, Uri endpoint, TestWorkerService service) : IAsyncDisposable
+    {
+        public Uri Endpoint { get; } = endpoint;
+
+        public TestWorkerService Service { get; } = service;
+
+        public static async Task<TestWorker> StartAsync(string workerId)
+        {
+            WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.ConfigureKestrel(options =>
+                options.Listen(IPAddress.Loopback, 0, listener => listener.Protocols = HttpProtocols.Http2));
+            TestWorkerService service = new(workerId);
+            builder.Services.AddSingleton(service);
+            builder.Services.AddGrpc();
+            WebApplication application = builder.Build();
+            application.MapGrpcService<TestWorkerService>();
+            await application.StartAsync();
+            IServer server = application.Services.GetRequiredService<IServer>();
+            string address = server.Features.Get<IServerAddressesFeature>()!.Addresses.Single();
+
+            return new(application, new Uri(address), service);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await application.StopAsync();
+            await application.DisposeAsync();
+        }
+    }
+
+    public sealed class TestWorkerService(string workerId) : FunctionRpc.FunctionRpcBase
+    {
+        private int _metadataRequests;
+
+        public int MetadataRequests => Interlocked.CompareExchange(ref _metadataRequests, 0, 0);
+
+        public TaskCompletionSource FunctionLoaded { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Disconnected { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async Task EventStream(IAsyncStreamReader<StreamingMessage> requestStream,
+            IServerStreamWriter<StreamingMessage> responseStream, ServerCallContext context)
+        {
+            try
+            {
+                await responseStream.WriteAsync(new() { StartStream = new() { WorkerId = workerId } });
+                while (await requestStream.MoveNext(context.CancellationToken))
+                {
+                    StreamingMessage request = requestStream.Current;
+                    StreamingMessage response = new() { RequestId = request.RequestId };
+                    switch (request.ContentCase)
+                    {
+                        case StreamingMessage.ContentOneofCase.WorkerInitRequest:
+                            response.WorkerInitResponse = new() { Result = Success() };
+                            break;
+                        case StreamingMessage.ContentOneofCase.FunctionsMetadataRequest:
+                            Interlocked.Increment(ref _metadataRequests);
+                            response.FunctionMetadataResponse = new() { Result = Success() };
+                            response.FunctionMetadataResponse.FunctionMetadataResults.Add(new RpcFunctionMetadata
+                            {
+                                FunctionId = "http",
+                                Name = "Http",
+                                Language = "dotnet-isolated",
+                                ScriptFile = "Sample.dll",
+                                EntryPoint = "Sample.Http.Run",
+                                Status = Success(),
+                                RawBindings =
+                                {
+                                    """{"name":"req","type":"httpTrigger","direction":"in","authLevel":"anonymous","methods":["get"]}""",
+                                    """{"name":"$return","type":"http","direction":"out"}""",
+                                },
+                            });
+                            break;
+                        case StreamingMessage.ContentOneofCase.FunctionLoadRequest:
+                            response.FunctionLoadResponse = new() { FunctionId = request.FunctionLoadRequest.FunctionId, Result = Success() };
+                            FunctionLoaded.TrySetResult();
+                            break;
+                        case StreamingMessage.ContentOneofCase.WorkerStatusRequest:
+                            response.WorkerStatusResponse = new();
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Unexpected worker request: {request.ContentCase}.");
+                    }
+
+                    await responseStream.WriteAsync(response);
+                }
+            }
+            catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                Disconnected.TrySetResult();
+            }
+        }
+
+        private static StatusResult Success() => new() { Status = StatusResult.Types.Status.Success };
+    }
+}

--- a/test/Functions.Rpc.Client.Tests/Hosting/RpcClientStartupTestHost.cs
+++ b/test/Functions.Rpc.Client.Tests/Hosting/RpcClientStartupTestHost.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+internal sealed class RpcClientStartupTestHost : IAsyncDisposable
+{
+    private readonly TaskCompletionSource<WorkerChannel> _firstLink = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public RpcClientStartupTestHost()
+    {
+        ScriptHostManager = ScriptHost.As<IScriptHostManager>();
+        ScriptHostManager.SetupGet(manager => manager.State).Returns(ScriptHostState.Running);
+        ScriptHost.Setup(host => host.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        ScriptHost.Setup(host => host.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        Registry.Setup(registry => registry.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        Registry.Setup(registry => registry.WaitForFirstInitializedAsync(It.IsAny<CancellationToken>()))
+            .Returns((CancellationToken token) =>
+            {
+                WaitEntered.TrySetResult();
+                return _firstLink.Task.WaitAsync(token);
+            });
+        Logger.Setup(logger => logger.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+        var loggerProvider = new Mock<ILoggerProvider>();
+        loggerProvider.Setup(provider => provider.CreateLogger(It.IsAny<string>())).Returns(Logger.Object);
+
+        Host = new HostBuilder().ConfigureServices(services =>
+        {
+            services.AddRpcClientWebHostServices(_ => ScriptHost.Object);
+            services.AddLogging(logging => logging.AddProvider(loggerProvider.Object));
+            services.Replace(ServiceDescriptor.Singleton<IWorkerChannelRegistry>(_ => Registry.Object));
+        }).Build();
+    }
+
+    public Mock<IHostedService> ScriptHost { get; } = new(MockBehavior.Strict);
+
+    public Mock<IScriptHostManager> ScriptHostManager { get; }
+
+    public Mock<IWorkerChannelRegistry> Registry { get; } = new(MockBehavior.Strict);
+
+    public Mock<ILogger> Logger { get; } = new();
+
+    public TaskCompletionSource WaitEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public IHost Host { get; }
+
+    public RpcClientScriptHostStartupCoordinator Coordinator => Host.Services.GetRequiredService<RpcClientScriptHostStartupCoordinator>();
+
+    public void CompleteLink() => _firstLink.TrySetResult(null!);
+
+    public ValueTask DisposeAsync() => ((IAsyncDisposable)Host).DisposeAsync();
+}

--- a/test/Functions.Rpc.Client.Tests/Metadata/RpcClientFunctionMetadataProviderTests.cs
+++ b/test/Functions.Rpc.Client.Tests/Metadata/RpcClientFunctionMetadataProviderTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Moq;
+using Xunit;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+public class RpcClientFunctionMetadataProviderTests
+{
+    [Fact]
+    public async Task GetFunctionMetadataAsync_UsesWorkerMetadataAndErrorsWithoutLocalWorkerConfiguration()
+    {
+        ImmutableArray<FunctionMetadata> functions = [new() { Name = "Http" }];
+        ImmutableDictionary<string, ImmutableArray<string>> errors =
+            ImmutableDictionary<string, ImmutableArray<string>>.Empty.Add("InvalidFunction", ["invalid binding"]);
+        var workerProvider = new Mock<IWorkerFunctionMetadataProvider>(MockBehavior.Strict);
+        workerProvider.Setup(provider => provider.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), true))
+            .ReturnsAsync(new FunctionMetadataResult(false, functions));
+        workerProvider.SetupGet(provider => provider.FunctionErrors).Returns(errors);
+        RpcClientFunctionMetadataProvider provider = new(workerProvider.Object);
+
+        Assert.Equal(functions, await provider.GetFunctionMetadataAsync([], forceRefresh: true));
+        Assert.Same(errors, provider.FunctionErrors);
+        workerProvider.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_DoesNotHidePreLinkFailure()
+    {
+        TimeoutException expected = new("No worker has initialized.");
+        var workerProvider = new Mock<IWorkerFunctionMetadataProvider>(MockBehavior.Strict);
+        workerProvider.Setup(provider => provider.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), false))
+            .ThrowsAsync(expected);
+        RpcClientFunctionMetadataProvider provider = new(workerProvider.Object);
+
+        Assert.Same(expected, await Assert.ThrowsAsync<TimeoutException>(() => provider.GetFunctionMetadataAsync([])));
+    }
+
+    [Fact]
+    public async Task GetFunctionMetadataAsync_RejectsHostIndexingFallback()
+    {
+        var workerProvider = new Mock<IWorkerFunctionMetadataProvider>(MockBehavior.Strict);
+        workerProvider.Setup(provider => provider.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), false))
+            .ReturnsAsync(new FunctionMetadataResult(true, []));
+        RpcClientFunctionMetadataProvider provider = new(workerProvider.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetFunctionMetadataAsync([]));
+    }
+}

--- a/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
+++ b/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Azure.Functions.Rpc.Client.Tests;
@@ -32,6 +33,8 @@ public class RpcClientAssemblyTests
         Assert.Contains("Microsoft.Azure.WebJobs.Script.Grpc", references);
         Assert.DoesNotContain("Azure.Functions.Rpc.Server", references);
         Assert.DoesNotContain("Azure.Functions.WorkerProxy", references);
+        Assert.DoesNotContain("Microsoft.Azure.WebJobs.Script.WebHost", references);
+        Assert.DoesNotContain("Azure.Functions.Host", references);
     }
 
     [Fact]
@@ -50,6 +53,23 @@ public class RpcClientAssemblyTests
         Assert.True(typeof(WorkerChannel).IsPublic);
         Assert.Equal(typeof(WorkerChannel), typeof(RpcClientWorkerChannel).BaseType);
         Assert.Equal("Azure.Functions.Rpc.Client", typeof(RpcClientWorkerChannel).Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void ClientRegistryAndStartupCoordinatorRemainInternal()
+    {
+        Assert.False(typeof(IWorkerChannelRegistry).IsPublic);
+        Assert.False(typeof(WorkerChannelRegistry).IsPublic);
+        Assert.False(typeof(RpcClientScriptHostStartupCoordinator).IsPublic);
+        Assert.Contains(typeof(IWorkerChannelRegistry), typeof(WorkerChannelRegistry).GetInterfaces());
+    }
+
+    [Fact]
+    public void ClientStartupCoordinatorUsesTheExistingHostedServiceContract()
+    {
+        var constructor = Assert.Single(typeof(RpcClientScriptHostStartupCoordinator).GetConstructors());
+        Assert.Contains(constructor.GetParameters(), parameter => parameter.ParameterType == typeof(IHostedService));
+        Assert.Equal(typeof(IWorkerChannelRegistry).Assembly, typeof(RpcClientScriptHostStartupCoordinator).Assembly);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Enable first-link ScriptHost activation for the Client-backed host. The root WebHost starts without waiting for a worker, then initiates ScriptHost startup after the first worker completes its FunctionRpc initialization handshake.

Addresses #11982 (HT8b), part of #11965.

## Changes

- Add an internal `RpcClientScriptHostStartupCoordinator` that calls `StartAsync` once after the first initialized worker becomes available. Concurrent or later links do not issue another startup call.
- Add `AddRpcClientWebHostServices`, with the thin `Functions.Host` composition supplying the existing `WebJobsScriptHostService` through its `IHostedService` contract. `Rpc.Client` does not gain a WebHost dependency.
- Route Host metadata requests through the existing root Client metadata provider and cache, rather than relying on local worker configuration or falling back to disk indexing.
- Coordinate cancellation and idempotent stop/disposal while leaving ownership of the ScriptHost service and worker channels with the root container.

The existing ScriptHost manager remains unchanged and continues to own retries, backoff, health handling, and shutdown. Activation-task completion is not a readiness signal; `IScriptHostManager.State` and `LastError` remain authoritative.

## Scope

Standard Server composition is unchanged. Host.json customization, worker-link HTTP endpoints, capacity publication, and broader timeout/cancellation hardening are deferred to follow-up work.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)