### PR TITLE
Bump Microsoft.Azure.AppService.Middleware to 1.5.12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageVersion Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.11" />
+    <PackageVersion Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.12" />
     <PackageVersion Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.3.20240307.67" />
     <PackageVersion Include="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" Version="1.0.5" />
     <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.24.0" />

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Fixed Linux language worker SIGTERM exits being reported as worker failures. (#11944)
 - Prevent extension system keys from being regenerated and overwritten when the startup context cache is stale, which previously could invalidate already-published extension webhook URLs (e.g. Event Grid, Durable Task). (#11936)
 - Ensure hosted services are stopped when application shutdown cancels startup, preventing IIS/ANCM from remaining stuck serving HTTP 500.30 (#11953)
+- Update Microsoft.Azure.AppService.Middleware to 1.5.12. (#12013)

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -15,7 +15,7 @@
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "10.0.0",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "10.0.0",
-          "Microsoft.Azure.AppService.Middleware.Functions": "1.5.11",
+          "Microsoft.Azure.AppService.Middleware.Functions": "1.5.12",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
           "Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption": "1.0.5",
           "Microsoft.Azure.WebJobs.Script": "4.1054.100-dev",
@@ -393,54 +393,54 @@
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware/1.5.11": {
+      "Microsoft.Azure.AppService.Middleware/1.5.12": {
         "dependencies": {
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.dll": {
-            "assemblyVersion": "1.5.11.0",
-            "fileVersion": "1.5.11.0"
+            "assemblyVersion": "1.5.12.0",
+            "fileVersion": "1.5.12.0"
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware.Functions/1.5.11": {
+      "Microsoft.Azure.AppService.Middleware.Functions/1.5.12": {
         "dependencies": {
-          "Microsoft.Azure.AppService.Middleware": "1.5.11",
-          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.11",
-          "Microsoft.Azure.AppService.Middleware.NetCore": "1.5.11"
+          "Microsoft.Azure.AppService.Middleware": "1.5.12",
+          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.12",
+          "Microsoft.Azure.AppService.Middleware.NetCore": "1.5.12"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.Functions.dll": {
-            "assemblyVersion": "1.5.11.0",
-            "fileVersion": "1.5.11.0"
+            "assemblyVersion": "1.5.12.0",
+            "fileVersion": "1.5.12.0"
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware.Modules/1.5.11": {
+      "Microsoft.Azure.AppService.Middleware.Modules/1.5.12": {
         "dependencies": {
-          "Microsoft.Azure.AppService.Middleware": "1.5.11",
+          "Microsoft.Azure.AppService.Middleware": "1.5.12",
           "Microsoft.IdentityModel.Validators": "6.32.0",
           "Newtonsoft.Json": "13.0.3",
           "System.IdentityModel.Tokens.Jwt": "8.15.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.Modules.dll": {
-            "assemblyVersion": "1.5.11.0",
-            "fileVersion": "1.5.11.0"
+            "assemblyVersion": "1.5.12.0",
+            "fileVersion": "1.5.12.0"
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware.NetCore/1.5.11": {
+      "Microsoft.Azure.AppService.Middleware.NetCore/1.5.12": {
         "dependencies": {
-          "Microsoft.Azure.AppService.Middleware": "1.5.11",
-          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.11",
+          "Microsoft.Azure.AppService.Middleware": "1.5.12",
+          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.12",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.NetCore.dll": {
-            "assemblyVersion": "1.5.11.0",
-            "fileVersion": "1.5.11.0"
+            "assemblyVersion": "1.5.12.0",
+            "fileVersion": "1.5.12.0"
           }
         }
       },
@@ -1891,33 +1891,33 @@
       "path": "microsoft.aspnetcore.razor.language/2.2.0",
       "hashPath": "microsoft.aspnetcore.razor.language.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware/1.5.11": {
+    "Microsoft.Azure.AppService.Middleware/1.5.12": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Qpwoquy42hdcetme32YX4WG/Ld8BC3gMW1oTK9Aqpet0UwfBrBoFbpAMoxix29okq1Bydy7kjhrnRE3DCNM1oA==",
-      "path": "microsoft.azure.appservice.middleware/1.5.11",
-      "hashPath": "microsoft.azure.appservice.middleware.1.5.11.nupkg.sha512"
+      "sha512": "sha512-LwgoL7nVWBOdH9elWs8CmJxsz2KFitgCMsT4AJCLkb0H3d7WRyANB8Ial4sW6Hu8elGMdMdf7WzblcHaQdTXtQ==",
+      "path": "microsoft.azure.appservice.middleware/1.5.12",
+      "hashPath": "microsoft.azure.appservice.middleware.1.5.12.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware.Functions/1.5.11": {
+    "Microsoft.Azure.AppService.Middleware.Functions/1.5.12": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-h8aUKefWIdQlclCl2GFyf/7c3ToCqx9KAapiyBXc2xNw+bz9rn49AH9mzDSwEdX7GaIY+h77Ia6AkchuXKZGGQ==",
-      "path": "microsoft.azure.appservice.middleware.functions/1.5.11",
-      "hashPath": "microsoft.azure.appservice.middleware.functions.1.5.11.nupkg.sha512"
+      "sha512": "sha512-5+xoHFp8BoibcpWwCizxxCcESH1ieTR9v6JW7G7KYp2G25GoXUTco+qwd3ynQLLW7vEfwR7laNFMqjX4yrnndg==",
+      "path": "microsoft.azure.appservice.middleware.functions/1.5.12",
+      "hashPath": "microsoft.azure.appservice.middleware.functions.1.5.12.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware.Modules/1.5.11": {
+    "Microsoft.Azure.AppService.Middleware.Modules/1.5.12": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AeTkI+Evf/wG4YeLGOaVDQPrNZWuHNjU2rDCwKe1ecG7j7CYccuxYKvsr4CnFAq+9SktxN3o76yCPLCwYwPF8g==",
-      "path": "microsoft.azure.appservice.middleware.modules/1.5.11",
-      "hashPath": "microsoft.azure.appservice.middleware.modules.1.5.11.nupkg.sha512"
+      "sha512": "sha512-cpG9NN1KmVc9H/FS1vJspCZ/pzgPhE/eMh2xAjLIaABxkW0ReeTgbz79tYy0dcpoV/6ebvLMmozPAM9/9K+p5Q==",
+      "path": "microsoft.azure.appservice.middleware.modules/1.5.12",
+      "hashPath": "microsoft.azure.appservice.middleware.modules.1.5.12.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware.NetCore/1.5.11": {
+    "Microsoft.Azure.AppService.Middleware.NetCore/1.5.12": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Yombcf2oQZMirp99FTxWcXjJtRi4UqsmfynKMrO6ZMPlSUfyh4sToTy9JY7Y0mVvwhldgq4Jn4i3UF5s9L/qaw==",
-      "path": "microsoft.azure.appservice.middleware.netcore/1.5.11",
-      "hashPath": "microsoft.azure.appservice.middleware.netcore.1.5.11.nupkg.sha512"
+      "sha512": "sha512-CfnZy3L+LB5d6aBhiqNRIldhB/dkLJR5pX1U1HA9ZGuFp1YavuNxtiKi/dZ3pmoeEuNhVBPw6EIiay+hB4h6Iw==",
+      "path": "microsoft.azure.appservice.middleware.netcore/1.5.12",
+      "hashPath": "microsoft.azure.appservice.middleware.netcore.1.5.12.nupkg.sha512"
     },
     "Microsoft.Azure.AppService.Proxy.Client/2.3.20240307.67": {
       "type": "package",


### PR DESCRIPTION
### Issue describing the changes in this PR

Bumps `Microsoft.Azure.AppService.Middleware.Functions` from `1.5.11` to `1.5.12`. Its existing transitive packages `Microsoft.Azure.AppService.Middleware`, `Microsoft.Azure.AppService.Middleware.Modules`, and `Microsoft.Azure.AppService.Middleware.NetCore` resolve to `1.5.12` as well.

### Pull request checklist

* [ ] Backporting to the `in-proc` branch is not required
    * NOTE: Please confirm whether this middleware update also needs an `in-proc` backport for Core Tools or non-Flex deployments.
* [x] My changes **do not** require documentation changes
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require diagnostic events changes
* [x] I have added all required tests (Unit tests, E2E tests)
    * Version-only bump; the existing WebHost dependency baseline test passes.

### Additional information

* Updated the centrally managed `Microsoft.Azure.AppService.Middleware.Functions` reference and refreshed the WebHost `deps.json` baseline for all four resolved middleware packages. No new package references were added.
* `dotnet restore .\src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj -v minimal` succeeded.
* `dotnet test .\test\WebJobs.Script.Tests\WebJobs.Script.Tests.csproj --filter "FullyQualifiedName~DependencyTests.Verify_DepsJsonChanges" -c Release -v minimal` passed (1/1).
