### PR TITLE
Fix Client test regressions after worker-link startup integration

### DIFF
--- a/test/Functions.Host.Tests/WorkerLinkTestHost.cs
+++ b/test/Functions.Host.Tests/WorkerLinkTestHost.cs
@@ -8,9 +8,9 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Functions.Host.Controllers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.TestHost;
@@ -22,8 +22,6 @@ using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
-using Microsoft.Azure.WebJobs.Script.Workers;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -76,7 +74,9 @@ internal sealed class WorkerLinkTestHost : IAsyncDisposable
                         if (includeCompute)
                         {
                             AddSharedChannelDependencies(services);
-                            ClientWorkerComposition.Instance.ConfigureWebHostServices(services, mvcBuilder);
+                            // This fixture isolates HTTP link admission from ScriptHost activation and metadata loading.
+                            services.AddRpcClientServices();
+                            mvcBuilder.AddApplicationPart(typeof(WorkerLinkController).Assembly);
                         }
 
                         services.AddAuthentication();

--- a/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
+++ b/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
@@ -56,9 +56,9 @@ public class RpcClientAssemblyTests
     }
 
     [Fact]
-    public void ClientRegistryAndStartupCoordinatorRemainInternal()
+    public void ClientRegistryAndStartupCoordinatorPreserveVisibilityBoundaries()
     {
-        Assert.False(typeof(IWorkerChannelRegistry).IsPublic);
+        Assert.True(typeof(IWorkerChannelRegistry).IsPublic);
         Assert.False(typeof(WorkerChannelRegistry).IsPublic);
         Assert.False(typeof(RpcClientScriptHostStartupCoordinator).IsPublic);
         Assert.Contains(typeof(IWorkerChannelRegistry), typeof(WorkerChannelRegistry).GetInterfaces());


### PR DESCRIPTION
Fix two test regressions on `dev` introduced by the worker-link registry and startup-coordinator integration (#12006 and #12011), without changing product behavior.

- Update the assembly-boundary assertion to expect the public `IWorkerChannelRegistry` contract while preserving the internal registry implementation and startup coordinator.
- Register RPC client services and the worker-link controller directly in the HTTP test fixture, keeping link-admission tests isolated from ScriptHost activation and metadata loading. Production composition remains covered by `ClientWorkerCompositionTests`.