### PR TITLE
Update System.Memory.Data to 10.0.12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,7 +88,7 @@
     <PackageVersion Include="System.IO.Abstractions" Version="2.1.0.227" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageVersion Include="System.Memory.Data" Version="8.0.1" />
+    <PackageVersion Include="System.Memory.Data" Version="10.0.12" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
@@ -37,6 +37,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void RuntimeAssemblies_PreviousSystemMemoryDataVersion_UnifiesToHostAssembly()
+        {
+            var functionContext = new FunctionAssemblyLoadContext(AppContext.BaseDirectory);
+            var assembly = functionContext.LoadFromAssemblyName(new AssemblyName("System.Memory.Data, Version=8.0.0.1"));
+
+            Assert.Same(typeof(BinaryData).Assembly, assembly);
+            Assert.Same(AssemblyLoadContext.Default, AssemblyLoadContext.GetLoadContext(assembly));
+        }
+
+        [Fact]
         public void InitializeDeps_LoadsExpectedDependencies()
         {
             string depsPath = Path.Combine(Directory.GetCurrentDirectory(), "Description", "DotNet", "TestFiles", "DepsFiles");

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -6,10 +6,10 @@
   "compilationOptions": {},
   "targets": {
     ".NETCoreApp,Version=v10.0": {
-      "Microsoft.Azure.WebJobs.Script.WebHost/4.1054.100-dev": {
+      "Microsoft.Azure.WebJobs.Script.WebHost/4.1055.100-dev": {
         "dependencies": {
           "AspNetCore.HealthChecks.UI.Client": "9.0.0",
-          "Azure.Functions.Rpc.Server": "4.1054.100-dev",
+          "Azure.Functions.Rpc.Server": "4.1055.100-dev",
           "Azure.Security.KeyVault.Secrets": "4.6.0",
           "Azure.Storage.Files.Shares": "12.24.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
@@ -18,13 +18,13 @@
           "Microsoft.Azure.AppService.Middleware.Functions": "1.5.11",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
           "Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption": "1.0.5",
-          "Microsoft.Azure.WebJobs.Script": "4.1054.100-dev",
-          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1054.100-dev",
+          "Microsoft.Azure.WebJobs.Script": "4.1055.100-dev",
+          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1055.100-dev",
           "Microsoft.Azure.WebSites.DataProtection": "2.1.91-alpha",
           "Microsoft.Security.Utilities.Core": "1.21.0",
-          "Azure.Functions.Rpc.Server.Reference": "4.1054.0.0",
-          "Microsoft.Azure.WebJobs.Script.Reference": "4.1054.0.0",
-          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.1054.0.0"
+          "Azure.Functions.Rpc.Server.Reference": "4.1055.0.0",
+          "Microsoft.Azure.WebJobs.Script.Reference": "4.1055.0.0",
+          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.1055.0.0"
         },
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.WebHost.dll": {}
@@ -61,7 +61,7 @@
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.8.0",
-          "System.Memory.Data": "8.0.1"
+          "System.Memory.Data": "10.0.12"
         },
         "runtime": {
           "lib/net8.0/Azure.Core.dll": {
@@ -496,7 +496,7 @@
         "dependencies": {
           "Microsoft.Azure.WebJobs.Core": "3.0.46",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "8.0.1"
+          "System.Memory.Data": "10.0.12"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.dll": {
@@ -507,7 +507,7 @@
       },
       "Microsoft.Azure.WebJobs.Core/3.0.46": {
         "dependencies": {
-          "System.Memory.Data": "8.0.1"
+          "System.Memory.Data": "10.0.12"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
@@ -1392,7 +1392,7 @@
       },
       "System.ClientModel/1.8.0": {
         "dependencies": {
-          "System.Memory.Data": "8.0.1"
+          "System.Memory.Data": "10.0.12"
         },
         "runtime": {
           "lib/net9.0/System.ClientModel.dll": {
@@ -1471,11 +1471,11 @@
           }
         }
       },
-      "System.Memory.Data/8.0.1": {
+      "System.Memory.Data/10.0.12": {
         "runtime": {
-          "lib/net8.0/System.Memory.Data.dll": {
-            "assemblyVersion": "8.0.0.1",
-            "fileVersion": "8.0.1024.46610"
+          "lib/net10.0/System.Memory.Data.dll": {
+            "assemblyVersion": "10.0.0.12",
+            "fileVersion": "10.0.1226.42308"
           }
         }
       },
@@ -1566,12 +1566,12 @@
           }
         }
       },
-      "Azure.Functions.Rpc.Server/4.1054.100-dev": {
+      "Azure.Functions.Rpc.Server/4.1055.100-dev": {
         "dependencies": {
           "Grpc.AspNetCore": "2.55.0",
           "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.45",
-          "Microsoft.Azure.WebJobs.Script": "4.1054.100-dev",
-          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1054.100-dev",
+          "Microsoft.Azure.WebJobs.Script": "4.1055.100-dev",
+          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1055.100-dev",
           "Mono.Posix.NETStandard": "1.0.0"
         },
         "runtime": {
@@ -1580,7 +1580,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script/4.1054.100-dev": {
+      "Microsoft.Azure.WebJobs.Script/4.1055.100-dev": {
         "dependencies": {
           "Azure.Data.Tables": "12.8.3",
           "Azure.Monitor.OpenTelemetry.Exporter": "1.5.0",
@@ -1616,11 +1616,11 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc/4.1054.100-dev": {
+      "Microsoft.Azure.WebJobs.Script.Grpc/4.1055.100-dev": {
         "dependencies": {
           "Google.Protobuf": "3.23.1",
           "Grpc.Core.Api": "2.55.0",
-          "Microsoft.Azure.WebJobs.Script": "4.1054.100-dev"
+          "Microsoft.Azure.WebJobs.Script": "4.1055.100-dev"
         },
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
@@ -1628,26 +1628,26 @@
           }
         }
       },
-      "Azure.Functions.Rpc.Server.Reference/4.1054.0.0": {
+      "Azure.Functions.Rpc.Server.Reference/4.1055.0.0": {
         "runtime": {
           "Azure.Functions.Rpc.Server.dll": {
-            "assemblyVersion": "4.1054.0.0",
+            "assemblyVersion": "4.1055.0.0",
             "fileVersion": "42.42.42.4242"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Reference/4.1054.0.0": {
+      "Microsoft.Azure.WebJobs.Script.Reference/4.1055.0.0": {
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.dll": {
-            "assemblyVersion": "4.1054.0.0",
+            "assemblyVersion": "4.1055.0.0",
             "fileVersion": "42.42.42.4242"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1054.0.0": {
+      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1055.0.0": {
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
-            "assemblyVersion": "4.1054.0.0",
+            "assemblyVersion": "4.1055.0.0",
             "fileVersion": "42.42.42.4242"
           }
         }
@@ -1655,7 +1655,7 @@
     }
   },
   "libraries": {
-    "Microsoft.Azure.WebJobs.Script.WebHost/4.1054.100-dev": {
+    "Microsoft.Azure.WebJobs.Script.WebHost/4.1055.100-dev": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
@@ -2409,12 +2409,12 @@
       "path": "system.io.hashing/8.0.0",
       "hashPath": "system.io.hashing.8.0.0.nupkg.sha512"
     },
-    "System.Memory.Data/8.0.1": {
+    "System.Memory.Data/10.0.12": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-BVYuec3jV23EMRDeR7Dr1/qhx7369dZzJ9IWy2xylvb4YfXsrUxspWc4UWYid/tj4zZK58uGZqn2WQiaDMhmAg==",
-      "path": "system.memory.data/8.0.1",
-      "hashPath": "system.memory.data.8.0.1.nupkg.sha512"
+      "sha512": "sha512-MksC4vmN7pWANW4VpvVw0TUA6sWa1yvMlms594JBiSsCD/CXH5mlazos76+UE6lGE+6/TiBA3S5TLEp8mGsMQw==",
+      "path": "system.memory.data/10.0.12",
+      "hashPath": "system.memory.data.10.0.12.nupkg.sha512"
     },
     "System.Reactive/5.0.0": {
       "type": "package",
@@ -2465,32 +2465,32 @@
       "path": "yarp.reverseproxy/2.0.1",
       "hashPath": "yarp.reverseproxy.2.0.1.nupkg.sha512"
     },
-    "Azure.Functions.Rpc.Server/4.1054.100-dev": {
+    "Azure.Functions.Rpc.Server/4.1055.100-dev": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script/4.1054.100-dev": {
+    "Microsoft.Azure.WebJobs.Script/4.1055.100-dev": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc/4.1054.100-dev": {
+    "Microsoft.Azure.WebJobs.Script.Grpc/4.1055.100-dev": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Azure.Functions.Rpc.Server.Reference/4.1054.0.0": {
+    "Azure.Functions.Rpc.Server.Reference/4.1055.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Reference/4.1054.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Reference/4.1055.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1054.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1055.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""


### PR DESCRIPTION
<!-- Please provide all the information below. -->

### Issue describing the changes in this PR

No linked issue.

Update the centrally managed `System.Memory.Data` reference from `8.0.1` to `10.0.12`, the latest stable 10.x release at the time of this change, to align with the host's `net10.0` target framework. Removing the central pin alone would still resolve `8.0.1` through the current Azure SDK dependencies.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

- [ ] Backporting to the `in-proc` branch is not required
- [x] My changes **do not** require documentation changes
- [ ] My changes **should not** be added to the release notes for the next release
- [ ] My changes **do not** need to be backported to a previous version
- [x] My changes **do not** require diagnostic events changes
- [x] I have added all required tests (Unit tests, E2E tests)

Backport and release-note disposition are left for maintainer review; no backport is included in this PR.

### Additional information

- Refresh the generated WebHost dependency baseline to use `System.Memory.Data`'s `net10.0` asset. Regeneration also captures the current first-party host version metadata (`4.1054` to `4.1055`), which is excluded from the dependency comparison.
- Add a regression test confirming that an assembly request for the previously used `System.Memory.Data, Version=8.0.0.1` unifies to the current host assembly in the default load context.
- The intended assembly-version change is `8.0.0.1` to `10.0.0.12`; the public key token remains unchanged.

**Compatibility and validation**

| Validation | Result |
|---|---|
| Dependency baseline, runtime assembly loading, and BinaryData binding/RPC conversion | All 13 targeted tests passed |
| Microsoft ApiCompat: actual 8.0.1 `net8.0` DLL versus 10.0.12 `net10.0` DLL | No breaking API changes, including attribute and parameter-name rules; full reference resolution, no suppressions, zero warnings/errors |
| Consumer compiled against 8.0.1 and run unchanged against both DLLs on .NET 10 | All 53 compatibility assertions passed with each version |
| Decompiled implementation comparison | Four additive `FromFile`/`FromFileAsync` overloads; no concrete breaking behavior identified in existing implementations |

The compatibility evidence covers the exercised API and runtime scenarios, not an exhaustive guarantee that every possible behavior is identical.