### PR TITLE
moving Debug invocation logs to Trace

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 {
                     while (_inbound.TryRead(out var msg))
                     {
-                        if (debug && msg.ContentCase != MsgType.RpcLog)
+                        if (msg.ContentCase != MsgType.RpcLog)
                         {
                             Logger.ChannelReceivedMessage(_workerChannelLogger, _workerId, msg.ContentCase);
                         }
@@ -2018,28 +2018,16 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         }
 
         // EventId range is 800-899
-        private static class Logger
+        private static partial class Logger
         {
-            private static readonly Action<ILogger, string, MsgType, Exception> _channelReceivedMessage = LoggerMessage.Define<string, MsgType>(
-                LogLevel.Debug,
-                new EventId(820, nameof(ChannelReceivedMessage)),
-                "[channel] received {workerId}: {msgType}");
+            [LoggerMessage(820, LogLevel.Trace, "[channel] received {workerId}: {msgType}")]
+            internal static partial void ChannelReceivedMessage(ILogger logger, string workerId, ContentOneofCase msgType);
 
-            private static readonly Action<ILogger, string, Exception> _invocationResponseReceived = LoggerMessage.Define<string>(
-                LogLevel.Debug,
-                new EventId(821, nameof(InvocationResponseReceived)),
-                "InvocationResponse received for invocation: '{invocationId}'");
+            [LoggerMessage(821, LogLevel.Trace, "InvocationResponse received for invocation: '{invocationId}'")]
+            internal static partial void InvocationResponseReceived(ILogger logger, string invocationId);
 
-            private static readonly Action<ILogger, string, Exception> _failedToRegisterAppCapabilities = LoggerMessage.Define<string>(
-                LogLevel.Warning,
-                new EventId(822, nameof(FailedToRegisterAppCapabilities)),
-                "Failed to register app capabilities from worker '{workerId}'");
-
-            internal static void ChannelReceivedMessage(ILogger logger, string workerId, ContentOneofCase msgType) => _channelReceivedMessage(logger, workerId, msgType, null);
-
-            internal static void InvocationResponseReceived(ILogger logger, string invocationId) => _invocationResponseReceived(logger, invocationId, null);
-
-            internal static void FailedToRegisterAppCapabilities(ILogger logger, Exception ex, string workerId) => _failedToRegisterAppCapabilities(logger, workerId, ex);
+            [LoggerMessage(822, LogLevel.Warning, "Failed to register app capabilities from worker '{workerId}'")]
+            internal static partial void FailedToRegisterAppCapabilities(ILogger logger, Exception ex, string workerId);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1374,9 +1374,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var expectedLog = "InvocationResponse received for invocation: 'TestInvocationId'";
             await TestHelpers.Await(
-                () => _logger.GetLogMessages().Any(m => string.Equals(m.FormattedMessage, expectedLog)),
+                () => _logger.GetLogMessages().Any(m => string.Equals(m.FormattedMessage, expectedLog, StringComparison.Ordinal)),
                 timeout: 3000,
                 pollingInterval: 50);
+
+            var traces = _logger.GetLogMessages();
+            var invocationResponseLog = Assert.Single(traces, m => string.Equals(m.FormattedMessage, expectedLog, StringComparison.Ordinal));
+            Assert.Equal(LogLevel.Trace, invocationResponseLog.Level);
+            Assert.Equal(821, invocationResponseLog.EventId.Id);
+            Assert.Equal("InvocationResponseReceived", invocationResponseLog.EventId.Name);
+
+            var channelReceivedLog = Assert.Single(traces, m => string.Equals(
+                m.FormattedMessage, $"[channel] received {_workerId}: InvocationResponse", StringComparison.Ordinal));
+            Assert.Equal(LogLevel.Trace, channelReceivedLog.Level);
+            Assert.Equal(820, channelReceivedLog.EventId.Id);
+            Assert.Equal("ChannelReceivedMessage", channelReceivedLog.EventId.Name);
         }
 
         [Fact]
@@ -1397,6 +1409,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var traces = _logger.GetLogMessages();
             ShowOutput(traces);
+
+            Assert.Contains(traces, m => m.Level == LogLevel.Trace && string.Equals(
+                m.FormattedMessage, $"[channel] received {_workerId}: FunctionLoadResponse", StringComparison.Ordinal));
 
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js1' with functionId: 'TestFunctionId1'")), "FunctionInvocationBuffer TestFunctionId1");
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js2' with functionId: 'TestFunctionId2'")), "FunctionInvocationBuffer TestFunctionId2");


### PR DESCRIPTION
Moving two unnecessary Debug logs to Trace. This will improve hot-path logging levels and reduce logs in our backend systems.

Took this opportunity to swap these logs to source-generated logging as well.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)